### PR TITLE
feat: Additional WS message encryption

### DIFF
--- a/backend/internal/agent/agent.go
+++ b/backend/internal/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OrcaCD/orca-cd/internal/agent/docker"
 	messages "github.com/OrcaCD/orca-cd/internal/proto"
 	"github.com/OrcaCD/orca-cd/internal/version"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/proto"
@@ -24,6 +25,7 @@ type Config struct {
 	LogJSON   bool
 	HubUrl    string
 	AuthToken string
+	AgentID   string
 }
 
 func DefaultConfig() (Config, error) {
@@ -41,6 +43,11 @@ func DefaultConfig() (Config, error) {
 		return Config{}, errors.New("AUTH_TOKEN is required")
 	}
 
+	agentID, err := parseAgentID(authToken)
+	if err != nil {
+		return Config{}, fmt.Errorf("AUTH_TOKEN: %w", err)
+	}
+
 	logLevel, err := zerolog.ParseLevel(logLevelStr)
 	if err != nil || logLevelStr == "" {
 		logLevel = zerolog.InfoLevel
@@ -53,7 +60,21 @@ func DefaultConfig() (Config, error) {
 		LogJSON:   logJSON,
 		HubUrl:    hubUrl,
 		AuthToken: authToken,
+		AgentID:   agentID,
 	}, nil
+}
+
+func parseAgentID(authToken string) (string, error) {
+	p := jwt.NewParser()
+	token, _, err := p.ParseUnverified(authToken, &jwt.RegisteredClaims{})
+	if err != nil {
+		return "", fmt.Errorf("could not parse token to extract agent ID: %w", err)
+	}
+	claims, ok := token.Claims.(*jwt.RegisteredClaims)
+	if !ok || claims.Subject == "" {
+		return "", errors.New("token is missing subject claim")
+	}
+	return claims.Subject, nil
 }
 
 func newLogger(logJSON bool) zerolog.Logger {
@@ -120,6 +141,13 @@ func Run(cfg Config) error {
 		return nil
 	}
 
+	session, err := performHandshake(conn, cfg.AgentID)
+	if err != nil {
+		Log.Error().Err(err).Msg("handshake failed")
+		_ = conn.Close()
+		return fmt.Errorf("handshake: %w", err)
+	}
+
 	for {
 		_, data, readErr := conn.ReadMessage()
 		if readErr != nil {
@@ -136,6 +164,12 @@ func Run(cfg Config) error {
 				Log.Info().Msg("agent stopped")
 				return nil
 			}
+			session, err = performHandshake(conn, cfg.AgentID)
+			if err != nil {
+				Log.Error().Err(err).Msg("handshake failed on reconnect")
+				_ = conn.Close()
+				return fmt.Errorf("handshake on reconnect: %w", err)
+			}
 			continue
 		}
 		msg := &messages.ServerMessage{}
@@ -143,6 +177,6 @@ func Run(cfg Config) error {
 			Log.Error().Err(err).Msg("unmarshal error")
 			continue
 		}
-		handleServerMessage(msg, conn)
+		handleServerMessage(msg, conn, session)
 	}
 }

--- a/backend/internal/agent/agent_config_test.go
+++ b/backend/internal/agent/agent_config_test.go
@@ -1,14 +1,24 @@
 package agent
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/rs/zerolog"
 )
 
+// testAgentToken is a minimal JWT-format string with a known subject.
+// The signature is intentionally fake; DefaultConfig only calls jwt.ParseUnverified,
+// which does not check the signature.
+var testAgentToken = func() string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"EdDSA","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"test-agent-id"}`))
+	return header + "." + payload + ".fakesig"
+}()
+
 func TestDefaultConfig_Valid(t *testing.T) {
 	t.Setenv("HUB_URL", "https://hub.example.com")
-	t.Setenv("AUTH_TOKEN", "test-token")
+	t.Setenv("AUTH_TOKEN", testAgentToken)
 	t.Setenv("LOG_LEVEL", "debug")
 	t.Setenv("LOG_JSON", "true")
 
@@ -26,14 +36,17 @@ func TestDefaultConfig_Valid(t *testing.T) {
 	if cfg.HubUrl != "wss://hub.example.com/api/v1/ws" {
 		t.Errorf("HubUrl = %q, want %q", cfg.HubUrl, "wss://hub.example.com/api/v1/ws")
 	}
-	if cfg.AuthToken != "test-token" {
-		t.Errorf("AuthToken = %q, want %q", cfg.AuthToken, "test-token")
+	if cfg.AuthToken != testAgentToken {
+		t.Errorf("AuthToken = %q, want %q", cfg.AuthToken, testAgentToken)
+	}
+	if cfg.AgentID != "test-agent-id" {
+		t.Errorf("AgentID = %q, want %q", cfg.AgentID, "test-agent-id")
 	}
 }
 
 func TestDefaultConfig_Defaults(t *testing.T) {
 	t.Setenv("HUB_URL", "https://hub.example.com")
-	t.Setenv("AUTH_TOKEN", "test-token")
+	t.Setenv("AUTH_TOKEN", testAgentToken)
 	t.Setenv("LOG_LEVEL", "")
 	t.Setenv("LOG_JSON", "")
 
@@ -66,7 +79,7 @@ func TestDefaultConfig_LogLevels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			t.Setenv("HUB_URL", "https://hub.example.com")
-			t.Setenv("AUTH_TOKEN", "test-token")
+			t.Setenv("AUTH_TOKEN", testAgentToken)
 			t.Setenv("LOG_LEVEL", tt.input)
 
 			cfg, err := DefaultConfig()
@@ -95,7 +108,7 @@ func TestDefaultConfig_LogJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			t.Setenv("HUB_URL", "https://hub.example.com")
-			t.Setenv("AUTH_TOKEN", "test-token")
+			t.Setenv("AUTH_TOKEN", testAgentToken)
 			t.Setenv("LOG_JSON", tt.input)
 
 			cfg, err := DefaultConfig()
@@ -116,7 +129,7 @@ func TestDefaultConfig_Errors(t *testing.T) {
 		authToken string
 	}{
 		{"missing auth token", "https://hub.example.com", ""},
-		{"invalid hub url", "not-a-url", "test-token"},
+		{"invalid hub url", "not-a-url", testAgentToken},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/agent/agent_config_test.go
+++ b/backend/internal/agent/agent_config_test.go
@@ -1,9 +1,12 @@
 package agent
 
 import (
+	"context"
 	"encoding/base64"
 	"testing"
+	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 )
 
@@ -119,6 +122,42 @@ func TestDefaultConfig_LogJSON(t *testing.T) {
 				t.Errorf("LogJSON = %v, want %v", cfg.LogJSON, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseAgentID_MissingSubject(t *testing.T) {
+	// JWT with empty subject field.
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"EdDSA","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":""}`))
+	token := header + "." + payload + ".fakesig"
+
+	_, err := parseAgentID(token)
+	if err == nil {
+		t.Fatal("expected error for token with empty subject")
+	}
+}
+
+func TestParseAgentID_InvalidToken(t *testing.T) {
+	_, err := parseAgentID("not.a.jwt")
+	if err == nil {
+		t.Fatal("expected error for malformed JWT")
+	}
+}
+
+func TestConnTracker_SetAndCancelled_CancelledCtx(t *testing.T) {
+	srv := newTestServer(t, func(serverConn *websocket.Conn) {
+		serverConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)) //nolint:errcheck,gosec
+		_, _, _ = serverConn.ReadMessage()
+	})
+
+	clientConn := dialServer(t, srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so ctx.Err() != nil
+
+	var tracker connTracker
+	if cancelled := tracker.setAndCancelled(ctx, clientConn); !cancelled {
+		t.Error("expected setAndCancelled to return true for a pre-cancelled context")
 	}
 }
 

--- a/backend/internal/agent/websocket.go
+++ b/backend/internal/agent/websocket.go
@@ -2,22 +2,105 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"github.com/OrcaCD/orca-cd/internal/shared/wscrypto"
 	"github.com/gorilla/websocket"
 	"google.golang.org/protobuf/proto"
 )
 
-func handleServerMessage(msg *messages.ServerMessage, conn *websocket.Conn) {
+const handshakeTimeout = 15 * time.Second
+
+func performHandshake(conn *websocket.Conn, agentID string) (*wscrypto.Session, error) {
+	if err := conn.SetReadDeadline(time.Now().Add(handshakeTimeout)); err != nil {
+		return nil, fmt.Errorf("set read deadline: %w", err)
+	}
+
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("read KeyExchangeInit: %w", err)
+	}
+
+	serverMsg := &messages.ServerMessage{}
+	if err := proto.Unmarshal(data, serverMsg); err != nil {
+		return nil, fmt.Errorf("unmarshal KeyExchangeInit: %w", err)
+	}
+
+	init, ok := serverMsg.Payload.(*messages.ServerMessage_KeyExchangeInit)
+	if !ok {
+		return nil, fmt.Errorf("expected KeyExchangeInit, got %T", serverMsg.Payload)
+	}
+
+	mlkemCiphertext, agentX25519Pub, sessionKey, err := wscrypto.AgentHandshake(
+		init.KeyExchangeInit.MlkemEncapsulationKey,
+		init.KeyExchangeInit.X25519PublicKey,
+		agentID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("agent handshake: %w", err)
+	}
+
+	resp := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_KeyExchangeResponse{
+			KeyExchangeResponse: &messages.KeyExchangeResponse{
+				MlkemCiphertext:      mlkemCiphertext,
+				AgentX25519PublicKey: agentX25519Pub,
+			},
+		},
+	}
+	respData, err := proto.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("marshal KeyExchangeResponse: %w", err)
+	}
+	if err := conn.WriteMessage(websocket.BinaryMessage, respData); err != nil {
+		return nil, fmt.Errorf("send KeyExchangeResponse: %w", err)
+	}
+
+	// Clear the handshake deadline — the hub's read loop will set its own deadline.
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		return nil, fmt.Errorf("clear read deadline: %w", err)
+	}
+
+	Log.Debug().Str("agent_id", agentID).Msg("WS handshake complete")
+	return wscrypto.NewSession(sessionKey)
+}
+
+func sendMessage(conn *websocket.Conn, session *wscrypto.Session, msg *messages.ClientMessage) error {
+	outMsg := msg
+	if !wscrypto.AllowedUnencrypted(msg) {
+		env, err := session.Encrypt(msg)
+		if err != nil {
+			return fmt.Errorf("encrypt: %w", err)
+		}
+		outMsg = &messages.ClientMessage{
+			Payload: &messages.ClientMessage_EncryptedPayload{
+				EncryptedPayload: env,
+			},
+		}
+	}
+	data, err := proto.Marshal(outMsg)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	return conn.WriteMessage(websocket.BinaryMessage, data)
+}
+
+func handleServerMessage(msg *messages.ServerMessage, conn *websocket.Conn, session *wscrypto.Session) {
+	_, isEncrypted := msg.Payload.(*messages.ServerMessage_EncryptedPayload)
+	if !isEncrypted && !wscrypto.AllowedUnencrypted(msg) {
+		Log.Warn().Msgf("dropping unencrypted message of type %T", msg.Payload)
+		return
+	}
+
 	switch p := msg.Payload.(type) {
 	case *messages.ServerMessage_Ping:
 		latency := time.Now().UnixMilli() - p.Ping.Timestamp
 		Log.Debug().Msgf("ping received, latency: %dms", latency)
 
-		// Respond with Pong
 		pong := &messages.ClientMessage{
 			Payload: &messages.ClientMessage_Pong{
 				Pong: &messages.PongResponse{
@@ -25,16 +108,16 @@ func handleServerMessage(msg *messages.ServerMessage, conn *websocket.Conn) {
 				},
 			},
 		}
-		data, err := proto.Marshal(pong)
-
-		if err != nil {
-			Log.Error().Err(err).Msg("failed to marshal Pong response")
-			return
-		}
-		if err := conn.WriteMessage(websocket.BinaryMessage, data); err != nil {
+		if err := sendMessage(conn, session, pong); err != nil {
 			Log.Error().Err(err).Msg("failed to send Pong response")
+		}
+	case *messages.ServerMessage_EncryptedPayload:
+		inner := &messages.ServerMessage{}
+		if err := session.Decrypt(p.EncryptedPayload, inner); err != nil {
+			Log.Error().Err(err).Msg("failed to decrypt message")
 			return
 		}
+		handleServerMessage(inner, conn, session)
 	default:
 		Log.Warn().Msg("unknown message type received")
 	}
@@ -47,7 +130,7 @@ func connectWithRetry(ctx context.Context, url, authToken string) (*websocket.Co
 	)
 
 	if strings.HasPrefix(url, "ws://") {
-		Log.Warn().Msg("connecting over unencrypted WebSocket. Do not use this in production or over untrusted networks")
+		Log.Warn().Msg("connecting over http. Do not use this in production or over untrusted networks")
 	}
 
 	delay := initialDelay

--- a/backend/internal/agent/websocket.go
+++ b/backend/internal/agent/websocket.go
@@ -96,6 +96,21 @@ func handleServerMessage(msg *messages.ServerMessage, conn *websocket.Conn, sess
 		return
 	}
 
+	// Unwrap at most one layer of encryption to prevent a malicious server from
+	// crafting a chain of nested EncryptedPayloads that causes unbounded recursion.
+	if p, ok := msg.Payload.(*messages.ServerMessage_EncryptedPayload); ok {
+		inner := &messages.ServerMessage{}
+		if err := session.Decrypt(p.EncryptedPayload, inner); err != nil {
+			Log.Error().Err(err).Msg("failed to decrypt message")
+			return
+		}
+		if _, stillEncrypted := inner.Payload.(*messages.ServerMessage_EncryptedPayload); stillEncrypted {
+			Log.Warn().Msg("dropping doubly-encrypted message")
+			return
+		}
+		msg = inner
+	}
+
 	switch p := msg.Payload.(type) {
 	case *messages.ServerMessage_Ping:
 		latency := time.Now().UnixMilli() - p.Ping.Timestamp
@@ -111,13 +126,6 @@ func handleServerMessage(msg *messages.ServerMessage, conn *websocket.Conn, sess
 		if err := sendMessage(conn, session, pong); err != nil {
 			Log.Error().Err(err).Msg("failed to send Pong response")
 		}
-	case *messages.ServerMessage_EncryptedPayload:
-		inner := &messages.ServerMessage{}
-		if err := session.Decrypt(p.EncryptedPayload, inner); err != nil {
-			Log.Error().Err(err).Msg("failed to decrypt message")
-			return
-		}
-		handleServerMessage(inner, conn, session)
 	default:
 		Log.Warn().Msg("unknown message type received")
 	}
@@ -130,7 +138,7 @@ func connectWithRetry(ctx context.Context, url, authToken string) (*websocket.Co
 	)
 
 	if strings.HasPrefix(url, "ws://") {
-		Log.Warn().Msg("connecting over http. Do not use this in production or over untrusted networks")
+		Log.Warn().Msg("connecting over unencrypted WebSocket. Do not use this in production or over untrusted networks")
 	}
 
 	delay := initialDelay

--- a/backend/internal/agent/websocket_test.go
+++ b/backend/internal/agent/websocket_test.go
@@ -112,7 +112,7 @@ func TestHandleServerMessage_Ping(t *testing.T) {
 	if err := proto.Unmarshal(data, msg); err != nil {
 		t.Fatalf("unmarshal ping: %v", err)
 	}
-	handleServerMessage(msg, clientConn)
+	handleServerMessage(msg, clientConn, nil)
 
 	select {
 	case <-done:
@@ -144,7 +144,7 @@ func TestHandleServerMessage_UnknownPayload(t *testing.T) {
 	clientConn := dialServer(t, srv)
 	defer clientConn.Close() //nolint:errcheck
 
-	handleServerMessage(&messages.ServerMessage{}, clientConn)
+	handleServerMessage(&messages.ServerMessage{}, clientConn, nil)
 
 	select {
 	case <-writeReceived:

--- a/backend/internal/agent/websocket_test.go
+++ b/backend/internal/agent/websocket_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"github.com/OrcaCD/orca-cd/internal/shared/wscrypto"
 	"github.com/gorilla/websocket"
 	"google.golang.org/protobuf/proto"
 )
@@ -284,6 +285,279 @@ func TestConnectWithRetry_PreCancelledContext(t *testing.T) {
 	if conn != nil {
 		t.Errorf("expected nil conn, got non-nil")
 	}
+}
+
+func TestPerformHandshake_Success(t *testing.T) {
+	hubKeys, err := wscrypto.GenerateHubKeys()
+	if err != nil {
+		t.Fatalf("GenerateHubKeys: %v", err)
+	}
+
+	srv := newTestServer(t, func(serverConn *websocket.Conn) {
+		init := &messages.ServerMessage{
+			Payload: &messages.ServerMessage_KeyExchangeInit{
+				KeyExchangeInit: &messages.KeyExchangeInit{
+					MlkemEncapsulationKey: hubKeys.MLKEMEncapKey,
+					X25519PublicKey:       hubKeys.X25519PublicKey,
+				},
+			},
+		}
+		data, _ := proto.Marshal(init)
+		if err := serverConn.WriteMessage(websocket.BinaryMessage, data); err != nil {
+			t.Errorf("write init: %v", err)
+			return
+		}
+		serverConn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
+		_, respData, err := serverConn.ReadMessage()
+		if err != nil {
+			t.Errorf("read response: %v", err)
+			return
+		}
+		clientMsg := &messages.ClientMessage{}
+		if err := proto.Unmarshal(respData, clientMsg); err != nil {
+			t.Errorf("unmarshal response: %v", err)
+			return
+		}
+		resp := clientMsg.GetKeyExchangeResponse()
+		if resp == nil {
+			t.Error("expected KeyExchangeResponse")
+		}
+	})
+
+	conn := dialServer(t, srv)
+	session, err := performHandshake(conn, "agent-1")
+	if err != nil {
+		t.Fatalf("performHandshake: %v", err)
+	}
+	if session == nil {
+		t.Fatal("expected non-nil session")
+	}
+}
+
+func TestPerformHandshake_WrongMessageType(t *testing.T) {
+	srv := newTestServer(t, func(serverConn *websocket.Conn) {
+		// Send a Ping instead of KeyExchangeInit.
+		msg := &messages.ServerMessage{
+			Payload: &messages.ServerMessage_Ping{Ping: &messages.PingRequest{Timestamp: 1}},
+		}
+		data, _ := proto.Marshal(msg)
+		if err := serverConn.WriteMessage(websocket.BinaryMessage, data); err != nil {
+			t.Errorf("write: %v", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	})
+
+	conn := dialServer(t, srv)
+	_, err := performHandshake(conn, "agent-1")
+	if err == nil {
+		t.Fatal("expected error when server sends wrong message type")
+	}
+}
+
+func TestPerformHandshake_InvalidProtoData(t *testing.T) {
+	srv := newTestServer(t, func(serverConn *websocket.Conn) {
+		// Send bytes that are not valid protobuf.
+		if err := serverConn.WriteMessage(websocket.BinaryMessage, []byte{0xFF, 0xFF, 0xFF}); err != nil {
+			t.Errorf("write: %v", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	})
+
+	conn := dialServer(t, srv)
+	_, err := performHandshake(conn, "agent-1")
+	if err == nil {
+		t.Fatal("expected error for invalid protobuf data")
+	}
+}
+
+func TestSendMessage_AllowedUnencrypted(t *testing.T) {
+	var received *messages.ClientMessage
+	done := make(chan struct{})
+
+	srv := newTestServer(t, func(serverConn *websocket.Conn) {
+		defer close(done)
+		serverConn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
+		_, data, err := serverConn.ReadMessage()
+		if err != nil {
+			t.Errorf("read: %v", err)
+			return
+		}
+		msg := &messages.ClientMessage{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			t.Errorf("unmarshal: %v", err)
+			return
+		}
+		received = msg
+	})
+
+	conn := dialServer(t, srv)
+	pong := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_Pong{Pong: &messages.PongResponse{Timestamp: 42}},
+	}
+	if err := sendMessage(conn, nil, pong); err != nil {
+		t.Fatalf("sendMessage: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server to receive message")
+	}
+
+	if received == nil || received.GetPong() == nil {
+		t.Fatal("expected pong message to arrive unencrypted")
+	}
+	if received.GetPong().Timestamp != 42 {
+		t.Errorf("expected timestamp 42, got %d", received.GetPong().Timestamp)
+	}
+}
+
+func TestSendMessage_Encrypted(t *testing.T) {
+	sessionKey := make([]byte, 32)
+	session, err := wscrypto.NewSession(sessionKey)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	var received *messages.ClientMessage
+	done := make(chan struct{})
+
+	srv := newTestServer(t, func(serverConn *websocket.Conn) {
+		defer close(done)
+		serverConn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
+		_, data, err := serverConn.ReadMessage()
+		if err != nil {
+			t.Errorf("read: %v", err)
+			return
+		}
+		msg := &messages.ClientMessage{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			t.Errorf("unmarshal: %v", err)
+			return
+		}
+		received = msg
+	})
+
+	conn := dialServer(t, srv)
+	// KeyExchangeResponse is not allowed unencrypted — sendMessage must encrypt it.
+	innerMsg := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_KeyExchangeResponse{
+			KeyExchangeResponse: &messages.KeyExchangeResponse{},
+		},
+	}
+	if err := sendMessage(conn, session, innerMsg); err != nil {
+		t.Fatalf("sendMessage: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server to receive message")
+	}
+
+	if received == nil || received.GetEncryptedPayload() == nil {
+		t.Fatal("expected encrypted payload on the wire")
+	}
+}
+
+func TestHandleServerMessage_EncryptedPing(t *testing.T) {
+	sessionKey := make([]byte, 32)
+	session, err := wscrypto.NewSession(sessionKey)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	var receivedPong *messages.ClientMessage
+	done := make(chan struct{})
+
+	srv := newTestServer(t, func(serverConn *websocket.Conn) {
+		defer close(done)
+		serverConn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
+		_, data, err := serverConn.ReadMessage()
+		if err != nil {
+			t.Errorf("read pong: %v", err)
+			return
+		}
+		msg := &messages.ClientMessage{}
+		if err := proto.Unmarshal(data, msg); err != nil {
+			t.Errorf("unmarshal pong: %v", err)
+			return
+		}
+		receivedPong = msg
+	})
+
+	conn := dialServer(t, srv)
+
+	pingMsg := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_Ping{Ping: &messages.PingRequest{Timestamp: time.Now().UnixMilli()}},
+	}
+	env, err := session.Encrypt(pingMsg)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	encryptedMsg := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_EncryptedPayload{EncryptedPayload: env},
+	}
+
+	handleServerMessage(encryptedMsg, conn, session)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server to receive pong response")
+	}
+
+	if receivedPong == nil || receivedPong.GetPong() == nil {
+		t.Fatal("expected a Pong response after handling encrypted Ping")
+	}
+}
+
+func TestHandleServerMessage_EncryptedDecryptError(t *testing.T) {
+	sessionKey := make([]byte, 32)
+	session, err := wscrypto.NewSession(sessionKey)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	// Invalid ciphertext — AEGIS authentication will fail.
+	msg := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_EncryptedPayload{
+			EncryptedPayload: &messages.EncryptedPayload{
+				Nonce:      make([]byte, 32),
+				Ciphertext: []byte{0x01, 0x02},
+			},
+		},
+	}
+	handleServerMessage(msg, nil, session) // must return without panic
+}
+
+func TestHandleServerMessage_DoublyEncrypted(t *testing.T) {
+	sessionKey := make([]byte, 32)
+	session, err := wscrypto.NewSession(sessionKey)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	// Inner payload is itself an EncryptedPayload — should be dropped after one unwrap.
+	innerMsg := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_EncryptedPayload{
+			EncryptedPayload: &messages.EncryptedPayload{Nonce: make([]byte, 32), Ciphertext: []byte{0x01}},
+		},
+	}
+	env, err := session.Encrypt(innerMsg)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	msg := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_EncryptedPayload{EncryptedPayload: env},
+	}
+	handleServerMessage(msg, nil, session) // must drop without panic
+}
+
+func TestHandleServerMessage_DropsUnencryptedNonPing(t *testing.T) {
+	// KeyExchangeInit is not a Ping and not wrapped in EncryptedPayload — must be dropped.
+	msg := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_KeyExchangeInit{KeyExchangeInit: &messages.KeyExchangeInit{}},
+	}
+	handleServerMessage(msg, nil, nil) // must return without panic
 }
 
 func TestConnTracker_CloseNilConn(t *testing.T) {

--- a/backend/internal/hub/websocket/handler.go
+++ b/backend/internal/hub/websocket/handler.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/OrcaCD/orca-cd/internal/hub/db"
 	"github.com/OrcaCD/orca-cd/internal/hub/models"
 	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"github.com/OrcaCD/orca-cd/internal/shared/wscrypto"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
@@ -17,6 +19,7 @@ import (
 )
 
 const pongWait = 90 * time.Second // must be greater than the worker ping interval (60s)
+const handshakeTimeout = 15 * time.Second
 
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
@@ -60,26 +63,37 @@ func WsHandler(h *Hub, log *zerolog.Logger) gin.HandlerFunc {
 			return
 		}
 
-		if err := conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
-			log.Error().Err(err).Msg("Failed to set read deadline")
+		conn.SetReadLimit(20 << 20) // 20MB max message size to prevent DoS with large messages
+
+		session, err := performHandshake(conn, claims.Subject, log)
+		if err != nil {
+			log.Error().Err(err).Str("agent_id", claims.Subject).Msg("Handshake failed")
 			err = conn.Close()
 			if err != nil {
-				log.Error().Err(err).Msg("Failed to close connection after read deadline error")
+				log.Error().Err(err).Str("agent_id", claims.Subject).Msg("Failed to close connection after handshake failure")
 			}
 			return
 		}
 
-		conn.SetReadLimit(20 << 20) // 20MB max message size to prevent DoS with large messages
+		if err := conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
+			log.Error().Err(err).Msg("Failed to set read deadline")
+			err = conn.Close()
+			if err != nil {
+				log.Error().Err(err).Str("agent_id", claims.Subject).Msg("Failed to close connection after read deadline error")
+			}
+			return
+		}
 
 		client, err := h.Register(claims.Subject, conn)
 		if err != nil {
 			log.Error().Err(err).Str("agent_id", claims.Subject).Msg("Failed to register client")
 			err = conn.Close()
 			if err != nil {
-				log.Error().Err(err).Msg("Failed to close connection after registration error")
+				log.Error().Err(err).Str("agent_id", claims.Subject).Msg("Failed to close connection after registration failure")
 			}
 			return
 		}
+		client.session = session
 
 		_, err = gorm.G[models.Agent](db.DB).Where("id = ?", claims.Subject).Update(c.Request.Context(), "status", models.AgentStatusOnline)
 		if err != nil {
@@ -116,23 +130,87 @@ func WsHandler(h *Hub, log *zerolog.Logger) gin.HandlerFunc {
 				continue
 			}
 
-			go handleClientMessage(claims.Subject, msg, log)
+			go handleClientMessage(client, msg, log)
 		}
 	}
 }
 
-func handleClientMessage(id string, msg *messages.ClientMessage, log *zerolog.Logger) {
+func handleClientMessage(client *Client, msg *messages.ClientMessage, log *zerolog.Logger) {
+	_, isEncrypted := msg.Payload.(*messages.ClientMessage_EncryptedPayload)
+	if !isEncrypted && !wscrypto.AllowedUnencrypted(msg) {
+		log.Warn().Str("client", client.Id).Msgf("dropping unencrypted message of type %T", msg.Payload)
+		return
+	}
+
 	switch p := msg.Payload.(type) {
 	case *messages.ClientMessage_Pong:
-		log.Debug().Str("client", id).Msgf("Pong received, timestamp: %d", p.Pong.Timestamp)
+		log.Debug().Str("client", client.Id).Msgf("Pong received, timestamp: %d", p.Pong.Timestamp)
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		lastSeen := time.Unix(p.Pong.Timestamp, 0)
-		_, err := gorm.G[models.Agent](db.DB).Where("id = ?", id).Update(ctx, "last_seen", lastSeen)
+		_, err := gorm.G[models.Agent](db.DB).Where("id = ?", client.Id).Update(ctx, "last_seen", lastSeen)
 		if err != nil {
-			log.Error().Err(err).Str("client", id).Msg("Failed to update last_seen")
+			log.Error().Err(err).Str("client", client.Id).Msg("Failed to update last_seen")
 		}
+	case *messages.ClientMessage_EncryptedPayload:
+		inner := &messages.ClientMessage{}
+		if err := client.session.Decrypt(p.EncryptedPayload, inner); err != nil {
+			log.Error().Err(err).Str("client", client.Id).Msg("Failed to decrypt message")
+			return
+		}
+		handleClientMessage(client, inner, log)
 	default:
-		log.Warn().Str("client", id).Msg("Unknown message type received")
+		log.Warn().Str("client", client.Id).Msg("Unknown message type received")
 	}
+}
+
+func performHandshake(conn *websocket.Conn, agentID string, log *zerolog.Logger) (*wscrypto.Session, error) {
+	hubKeys, err := wscrypto.GenerateHubKeys()
+	if err != nil {
+		return nil, err
+	}
+
+	init := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_KeyExchangeInit{
+			KeyExchangeInit: &messages.KeyExchangeInit{
+				MlkemEncapsulationKey: hubKeys.MLKEMEncapKey,
+				X25519PublicKey:       hubKeys.X25519PublicKey,
+			},
+		},
+	}
+	initData, err := proto.Marshal(init)
+	if err != nil {
+		return nil, err
+	}
+	if err := conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
+		return nil, err
+	}
+	if err := conn.WriteMessage(websocket.BinaryMessage, initData); err != nil {
+		return nil, err
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(handshakeTimeout)); err != nil {
+		return nil, err
+	}
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+
+	clientMsg := &messages.ClientMessage{}
+	if err := proto.Unmarshal(data, clientMsg); err != nil {
+		return nil, err
+	}
+	resp, ok := clientMsg.Payload.(*messages.ClientMessage_KeyExchangeResponse)
+	if !ok {
+		return nil, fmt.Errorf("expected KeyExchangeResponse, got %T", clientMsg.Payload)
+	}
+
+	sessionKey, err := wscrypto.HubDeriveSessionKey(hubKeys, resp.KeyExchangeResponse.MlkemCiphertext, resp.KeyExchangeResponse.AgentX25519PublicKey, agentID)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debug().Str("agent_id", agentID).Msg("WS handshake complete")
+	return wscrypto.NewSession(sessionKey)
 }

--- a/backend/internal/hub/websocket/handler.go
+++ b/backend/internal/hub/websocket/handler.go
@@ -142,23 +142,31 @@ func handleClientMessage(client *Client, msg *messages.ClientMessage, log *zerol
 		return
 	}
 
-	switch p := msg.Payload.(type) {
-	case *messages.ClientMessage_Pong:
-		log.Debug().Str("client", client.Id).Msgf("Pong received, timestamp: %d", p.Pong.Timestamp)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		lastSeen := time.Unix(p.Pong.Timestamp, 0)
-		_, err := gorm.G[models.Agent](db.DB).Where("id = ?", client.Id).Update(ctx, "last_seen", lastSeen)
-		if err != nil {
-			log.Error().Err(err).Str("client", client.Id).Msg("Failed to update last_seen")
-		}
-	case *messages.ClientMessage_EncryptedPayload:
+	// Unwrap at most one layer of encryption to prevent a malicious client from
+	// crafting a chain of nested EncryptedPayloads that causes unbounded recursion.
+	if p, ok := msg.Payload.(*messages.ClientMessage_EncryptedPayload); ok {
 		inner := &messages.ClientMessage{}
 		if err := client.session.Decrypt(p.EncryptedPayload, inner); err != nil {
 			log.Error().Err(err).Str("client", client.Id).Msg("Failed to decrypt message")
 			return
 		}
-		handleClientMessage(client, inner, log)
+		if _, stillEncrypted := inner.Payload.(*messages.ClientMessage_EncryptedPayload); stillEncrypted {
+			log.Warn().Str("client", client.Id).Msg("Dropping doubly-encrypted message")
+			return
+		}
+		msg = inner
+	}
+
+	switch p := msg.Payload.(type) {
+	case *messages.ClientMessage_Pong:
+		log.Debug().Str("client", client.Id).Msgf("Pong received, timestamp: %d", p.Pong.Timestamp)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		lastSeen := time.UnixMilli(p.Pong.Timestamp)
+		_, err := gorm.G[models.Agent](db.DB).Where("id = ?", client.Id).Update(ctx, "last_seen", lastSeen)
+		if err != nil {
+			log.Error().Err(err).Str("client", client.Id).Msg("Failed to update last_seen")
+		}
 	default:
 		log.Warn().Str("client", client.Id).Msg("Unknown message type received")
 	}

--- a/backend/internal/hub/websocket/handler_test.go
+++ b/backend/internal/hub/websocket/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OrcaCD/orca-cd/internal/hub/db"
 	"github.com/OrcaCD/orca-cd/internal/hub/models"
 	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"github.com/OrcaCD/orca-cd/internal/shared/wscrypto"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
@@ -142,6 +143,52 @@ func waitForOffline(t *testing.T, agentId string) {
 	t.Errorf("timed out waiting for agent %s to go offline", agentId)
 }
 
+func doHandshake(t *testing.T, conn *websocket.Conn, agentID string) {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Errorf("doHandshake: set deadline: %v", err)
+		return
+	}
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Errorf("doHandshake: read: %v", err)
+		return
+	}
+	serverMsg := &messages.ServerMessage{}
+	if err := proto.Unmarshal(data, serverMsg); err != nil {
+		t.Errorf("doHandshake: unmarshal: %v", err)
+		return
+	}
+	init := serverMsg.GetKeyExchangeInit()
+	if init == nil {
+		t.Errorf("doHandshake: expected KeyExchangeInit, got %T", serverMsg.Payload)
+		return
+	}
+	mlkemCiphertext, agentX25519Pub, _, err := wscrypto.AgentHandshake(
+		init.MlkemEncapsulationKey,
+		init.X25519PublicKey,
+		agentID,
+	)
+	if err != nil {
+		t.Errorf("doHandshake: AgentHandshake: %v", err)
+		return
+	}
+	resp := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_KeyExchangeResponse{
+			KeyExchangeResponse: &messages.KeyExchangeResponse{
+				MlkemCiphertext:      mlkemCiphertext,
+				AgentX25519PublicKey: agentX25519Pub,
+			},
+		},
+	}
+	respData, _ := proto.Marshal(resp)
+	if err := conn.WriteMessage(websocket.BinaryMessage, respData); err != nil {
+		t.Errorf("doHandshake: send response: %v", err)
+		return
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+}
+
 func TestWsHandler_MissingAuthHeader(t *testing.T) {
 	setupHandlerTestEnv(t)
 	log := testLogger()
@@ -252,6 +299,7 @@ func TestWsHandler_Success_ReceivesPing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected successful WS connection, got: %v", err)
 	}
+	doHandshake(t, conn, agent.Id)
 
 	// Wait for the server to register the client (with timeout).
 	msg := &messages.ServerMessage{
@@ -312,6 +360,7 @@ func TestWsHandler_HandlesPong(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected successful WS connection, got: %v", err)
 	}
+	doHandshake(t, conn, agent.Id)
 
 	// Wait for registration.
 	deadline := time.Now().Add(time.Second)
@@ -380,6 +429,7 @@ func TestWsHandler_AgentMarkedOfflineOnDisconnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected successful WS connection, got: %v", err)
 	}
+	doHandshake(t, conn, agent.Id)
 
 	// Wait for registration then close the connection.
 	deadline := time.Now().Add(time.Second)

--- a/backend/internal/hub/websocket/handler_test.go
+++ b/backend/internal/hub/websocket/handler_test.go
@@ -181,7 +181,10 @@ func doHandshake(t *testing.T, conn *websocket.Conn, agentID string) {
 			},
 		},
 	}
-	respData, _ := proto.Marshal(resp)
+	respData, err := proto.Marshal(resp)
+	if err != nil {
+		t.Fatalf("doHandshake: marshal response: %v", err)
+	}
 	if err := conn.WriteMessage(websocket.BinaryMessage, respData); err != nil {
 		t.Errorf("doHandshake: send response: %v", err)
 		return

--- a/backend/internal/hub/websocket/handler_test.go
+++ b/backend/internal/hub/websocket/handler_test.go
@@ -416,6 +416,88 @@ func TestWsHandler_HandlesPong(t *testing.T) {
 	waitForOffline(t, agent.Id)
 }
 
+func TestHandleClientMessage_DropsUnencryptedNonPong(t *testing.T) {
+	log := testLogger()
+	client := &Client{Id: "test", Send: make(chan *messages.ServerMessage, 1)}
+	// KeyExchangeResponse is neither encrypted nor a Pong — must be dropped silently.
+	msg := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_KeyExchangeResponse{
+			KeyExchangeResponse: &messages.KeyExchangeResponse{},
+		},
+	}
+	handleClientMessage(client, msg, &log) // must not panic or block
+}
+
+func TestHandleClientMessage_DecryptError(t *testing.T) {
+	log := testLogger()
+	sessionKey := make([]byte, 32)
+	session, err := wscrypto.NewSession(sessionKey)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	client := &Client{Id: "test", Send: make(chan *messages.ServerMessage, 1), session: session}
+	msg := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_EncryptedPayload{
+			EncryptedPayload: &messages.EncryptedPayload{
+				Nonce:      make([]byte, 32),
+				Ciphertext: []byte{0x01, 0x02}, // invalid ciphertext — auth tag will fail
+			},
+		},
+	}
+	handleClientMessage(client, msg, &log) // must return without panic
+}
+
+func TestHandleClientMessage_DoublyEncrypted(t *testing.T) {
+	log := testLogger()
+	sessionKey := make([]byte, 32)
+	session, err := wscrypto.NewSession(sessionKey)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	client := &Client{Id: "test", Send: make(chan *messages.ServerMessage, 1), session: session}
+
+	// Encrypt a message whose inner payload is itself an EncryptedPayload.
+	innerMsg := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_EncryptedPayload{
+			EncryptedPayload: &messages.EncryptedPayload{Nonce: make([]byte, 32), Ciphertext: []byte{0x01}},
+		},
+	}
+	env, err := session.Encrypt(innerMsg)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	msg := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_EncryptedPayload{EncryptedPayload: env},
+	}
+	handleClientMessage(client, msg, &log) // doubly-encrypted — must be dropped
+}
+
+func TestHandleClientMessage_EncryptedUnknownPayload(t *testing.T) {
+	setupHandlerTestEnv(t)
+	log := testLogger()
+	sessionKey := make([]byte, 32)
+	session, err := wscrypto.NewSession(sessionKey)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	client := &Client{Id: "test", Send: make(chan *messages.ServerMessage, 1), session: session}
+
+	// Encrypt a message type that falls into the default switch branch.
+	innerMsg := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_KeyExchangeResponse{
+			KeyExchangeResponse: &messages.KeyExchangeResponse{},
+		},
+	}
+	env, err := session.Encrypt(innerMsg)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	msg := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_EncryptedPayload{EncryptedPayload: env},
+	}
+	handleClientMessage(client, msg, &log) // hits the "unknown message type" default case
+}
+
 func TestWsHandler_AgentMarkedOfflineOnDisconnect(t *testing.T) {
 	setupHandlerTestEnv(t)
 	log := testLogger()

--- a/backend/internal/hub/websocket/hub.go
+++ b/backend/internal/hub/websocket/hub.go
@@ -6,15 +6,17 @@ import (
 	"time"
 
 	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"github.com/OrcaCD/orca-cd/internal/shared/wscrypto"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/proto"
 )
 
 type Client struct {
-	Id   string
-	conn *websocket.Conn
-	Send chan *messages.ServerMessage
+	Id      string
+	conn    *websocket.Conn
+	Send    chan *messages.ServerMessage
+	session *wscrypto.Session
 }
 
 // Close signals the WritePump to stop.
@@ -98,7 +100,30 @@ func (h *Hub) WritePump(c *Client, log *zerolog.Logger) {
 	}()
 
 	for msg := range c.Send {
-		data, err := proto.Marshal(msg)
+		allowedUnencrypted := wscrypto.AllowedUnencrypted(msg)
+
+		// Refuse to send sensitive messages before the handshake is complete.
+		if c.session == nil && !allowedUnencrypted {
+			log.Error().Str("client", c.Id).Msg("dropping message: session not established")
+			continue
+		}
+
+		outMsg := msg
+
+		if !allowedUnencrypted {
+			env, err := c.session.Encrypt(msg)
+			if err != nil {
+				log.Error().Err(err).Msg("encrypt error")
+				continue
+			}
+			outMsg = &messages.ServerMessage{
+				Payload: &messages.ServerMessage_EncryptedPayload{
+					EncryptedPayload: env,
+				},
+			}
+		}
+
+		data, err := proto.Marshal(outMsg)
 		if err != nil {
 			log.Error().Err(err).Msg("Marshal error")
 			continue

--- a/backend/internal/hub/websocket/hub_test.go
+++ b/backend/internal/hub/websocket/hub_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"github.com/OrcaCD/orca-cd/internal/shared/wscrypto"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/proto"
@@ -335,6 +336,88 @@ func TestHub_WritePump(t *testing.T) {
 	}
 
 	// Close the send channel to stop WritePump
+	client.Close()
+}
+
+func TestHub_WritePump_DropsMessageWithNilSession(t *testing.T) {
+	log := testLogger()
+	h := NewHub(&log)
+
+	serverConn, clientConn := newWSPair(t)
+	defer clientConn.Close() //nolint:errcheck
+
+	client, err := h.Register("agent-nil-session", serverConn)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// session is intentionally nil
+	go h.WritePump(client, &log)
+
+	// KeyExchangeInit is not allowed unencrypted and session is nil — must be dropped.
+	msg := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_KeyExchangeInit{
+			KeyExchangeInit: &messages.KeyExchangeInit{},
+		},
+	}
+	client.Send <- msg
+	time.Sleep(50 * time.Millisecond)
+
+	// Close WritePump; the underlying serverConn will also be closed.
+	client.Close()
+
+	// clientConn should not have received any data message.
+	if err := clientConn.SetReadDeadline(time.Now().Add(300 * time.Millisecond)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	_, _, readErr := clientConn.ReadMessage()
+	if readErr == nil {
+		t.Error("expected no message (should have been dropped), but client received data")
+	}
+}
+
+func TestHub_WritePump_EncryptsNonPingMessages(t *testing.T) {
+	log := testLogger()
+	h := NewHub(&log)
+
+	serverConn, clientConn := newWSPair(t)
+	defer clientConn.Close() //nolint:errcheck
+
+	sessionKey := make([]byte, 32)
+	session, err := wscrypto.NewSession(sessionKey)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	client, err := h.Register("agent-encrypted", serverConn)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	client.session = session
+	go h.WritePump(client, &log)
+
+	// KeyExchangeInit is not allowed unencrypted — WritePump must encrypt it.
+	msg := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_KeyExchangeInit{
+			KeyExchangeInit: &messages.KeyExchangeInit{},
+		},
+	}
+	client.Send <- msg
+
+	if err := clientConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	_, data, err := clientConn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	received := &messages.ServerMessage{}
+	if err := proto.Unmarshal(data, received); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if received.GetEncryptedPayload() == nil {
+		t.Error("expected encrypted payload from WritePump")
+	}
+
 	client.Close()
 }
 

--- a/backend/internal/proto/messages.proto
+++ b/backend/internal/proto/messages.proto
@@ -7,18 +7,38 @@ option go_package = "./messages";
 message ClientMessage {
   oneof payload {
     PongResponse pong = 1;
+    KeyExchangeResponse key_exchange_response = 2;
+    EncryptedPayload encrypted_payload = 3;
   }
 }
 
 message ServerMessage {
   oneof payload {
     PingRequest ping = 1;
+    KeyExchangeInit key_exchange_init = 2;
+    EncryptedPayload encrypted_payload = 3;
   }
 }
 
 message PingRequest {
   int64 timestamp = 1;
 }
+
 message PongResponse {
   int64 timestamp = 1;
+}
+
+message KeyExchangeInit {
+  bytes mlkem_encapsulation_key = 1;
+  bytes x25519_public_key = 2;
+}
+
+message KeyExchangeResponse {
+  bytes mlkem_ciphertext = 1;
+  bytes agent_x25519_public_key = 2;
+}
+
+message EncryptedPayload {
+  bytes nonce = 1;
+  bytes ciphertext = 2;
 }

--- a/backend/internal/shared/wscrypto/allowlist.go
+++ b/backend/internal/shared/wscrypto/allowlist.go
@@ -1,0 +1,20 @@
+package wscrypto
+
+import (
+	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"google.golang.org/protobuf/proto"
+)
+
+// Only low-sensitivity control messages (Ping / Pong) are permitted unencrypted.
+func AllowedUnencrypted(msg proto.Message) bool {
+	switch m := msg.(type) {
+	case *messages.ServerMessage:
+		_, ok := m.Payload.(*messages.ServerMessage_Ping)
+		return ok
+	case *messages.ClientMessage:
+		_, ok := m.Payload.(*messages.ClientMessage_Pong)
+		return ok
+	default:
+		return false
+	}
+}

--- a/backend/internal/shared/wscrypto/allowlist_test.go
+++ b/backend/internal/shared/wscrypto/allowlist_test.go
@@ -1,0 +1,63 @@
+package wscrypto
+
+import (
+	"testing"
+
+	messages "github.com/OrcaCD/orca-cd/internal/proto"
+)
+
+func TestAllowedUnencrypted_ServerPing(t *testing.T) {
+	msg := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_Ping{Ping: &messages.PingRequest{Timestamp: 1}},
+	}
+	if !AllowedUnencrypted(msg) {
+		t.Error("expected ServerMessage Ping to be allowed unencrypted")
+	}
+}
+
+func TestAllowedUnencrypted_ServerNonPing(t *testing.T) {
+	msg := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_KeyExchangeInit{KeyExchangeInit: &messages.KeyExchangeInit{}},
+	}
+	if AllowedUnencrypted(msg) {
+		t.Error("expected ServerMessage KeyExchangeInit to be disallowed unencrypted")
+	}
+}
+
+func TestAllowedUnencrypted_ServerEmptyPayload(t *testing.T) {
+	msg := &messages.ServerMessage{}
+	if AllowedUnencrypted(msg) {
+		t.Error("expected ServerMessage with nil payload to be disallowed unencrypted")
+	}
+}
+
+func TestAllowedUnencrypted_ClientPong(t *testing.T) {
+	msg := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_Pong{Pong: &messages.PongResponse{Timestamp: 1}},
+	}
+	if !AllowedUnencrypted(msg) {
+		t.Error("expected ClientMessage Pong to be allowed unencrypted")
+	}
+}
+
+func TestAllowedUnencrypted_ClientNonPong(t *testing.T) {
+	msg := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_KeyExchangeResponse{KeyExchangeResponse: &messages.KeyExchangeResponse{}},
+	}
+	if AllowedUnencrypted(msg) {
+		t.Error("expected ClientMessage KeyExchangeResponse to be disallowed unencrypted")
+	}
+}
+
+func TestAllowedUnencrypted_ClientEmptyPayload(t *testing.T) {
+	msg := &messages.ClientMessage{}
+	if AllowedUnencrypted(msg) {
+		t.Error("expected ClientMessage with nil payload to be disallowed unencrypted")
+	}
+}
+
+func TestAllowedUnencrypted_OtherType(t *testing.T) {
+	if AllowedUnencrypted(&messages.PingRequest{Timestamp: 1}) {
+		t.Error("expected non-ServerMessage/ClientMessage to be disallowed unencrypted")
+	}
+}

--- a/backend/internal/shared/wscrypto/handshake.go
+++ b/backend/internal/shared/wscrypto/handshake.go
@@ -1,0 +1,103 @@
+package wscrypto
+
+import (
+	"crypto/ecdh"
+	"crypto/hkdf"
+	"crypto/mlkem"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+)
+
+const sessionKeyInfo = "WS_SESSION_KEY_v1"
+
+type HubHandshakeKeys struct {
+	mlkemDecapKey   *mlkem.DecapsulationKey768
+	x25519PrivKey   *ecdh.PrivateKey
+	MLKEMEncapKey   []byte // 1184 bytes — sent to agent in KeyExchangeInit
+	X25519PublicKey []byte // 32 bytes  — sent to agent in KeyExchangeInit
+}
+
+func GenerateHubKeys() (*HubHandshakeKeys, error) {
+	decapKey, err := mlkem.GenerateKey768()
+	if err != nil {
+		return nil, fmt.Errorf("mlkem key generation: %w", err)
+	}
+
+	x25519Priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("x25519 key generation: %w", err)
+	}
+
+	return &HubHandshakeKeys{
+		mlkemDecapKey:   decapKey,
+		x25519PrivKey:   x25519Priv,
+		MLKEMEncapKey:   decapKey.EncapsulationKey().Bytes(),
+		X25519PublicKey: x25519Priv.PublicKey().Bytes(),
+	}, nil
+}
+
+// Called by the agent
+func AgentHandshake(mlkemEncapKeyBytes, hubX25519PubBytes []byte, agentID string) (mlkemCiphertext, agentX25519PubKey, sessionKey []byte, err error) {
+	encapKey, err := mlkem.NewEncapsulationKey768(mlkemEncapKeyBytes)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("parse mlkem encapsulation key: %w", err)
+	}
+
+	mlkemShared, mlkemCiphertext := encapKey.Encapsulate()
+
+	agentX25519Priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("x25519 key generation: %w", err)
+	}
+
+	hubX25519Pub, err := ecdh.X25519().NewPublicKey(hubX25519PubBytes)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("parse hub x25519 public key: %w", err)
+	}
+
+	x25519Shared, err := agentX25519Priv.ECDH(hubX25519Pub)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("x25519 ecdh: %w", err)
+	}
+
+	sessionKey, err = deriveSessionKey(mlkemShared, x25519Shared, agentID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return mlkemCiphertext, agentX25519Priv.PublicKey().Bytes(), sessionKey, nil
+}
+
+// Called by the hub after receiving the agent's KeyExchangeResponse message
+func HubDeriveSessionKey(keys *HubHandshakeKeys, mlkemCiphertext, agentX25519PubBytes []byte, agentID string) ([]byte, error) {
+	mlkemShared, err := keys.mlkemDecapKey.Decapsulate(mlkemCiphertext)
+	if err != nil {
+		return nil, fmt.Errorf("mlkem decapsulate: %w", err)
+	}
+
+	agentX25519Pub, err := ecdh.X25519().NewPublicKey(agentX25519PubBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse agent x25519 public key: %w", err)
+	}
+
+	x25519Shared, err := keys.x25519PrivKey.ECDH(agentX25519Pub)
+	if err != nil {
+		return nil, fmt.Errorf("x25519 ecdh: %w", err)
+	}
+
+	return deriveSessionKey(mlkemShared, x25519Shared, agentID)
+}
+
+// combines the two shared secrets (both fixed-length: 32 bytes each) via HKDF-SHA256
+func deriveSessionKey(mlkemShared, x25519Shared []byte, agentID string) ([]byte, error) {
+	combined := make([]byte, len(mlkemShared)+len(x25519Shared))
+	copy(combined[:len(mlkemShared)], mlkemShared)
+	copy(combined[len(mlkemShared):], x25519Shared)
+
+	key, err := hkdf.Key(sha256.New, combined, []byte(agentID), sessionKeyInfo, 32)
+	if err != nil {
+		return nil, fmt.Errorf("hkdf key derivation: %w", err)
+	}
+	return key, nil
+}

--- a/backend/internal/shared/wscrypto/handshake_test.go
+++ b/backend/internal/shared/wscrypto/handshake_test.go
@@ -1,0 +1,84 @@
+package wscrypto
+
+import (
+	"bytes"
+	"crypto/subtle"
+	"testing"
+)
+
+func TestFullHandshake(t *testing.T) {
+	hubKeys, err := GenerateHubKeys()
+	if err != nil {
+		t.Fatalf("GenerateHubKeys: %v", err)
+	}
+
+	mlkemCiphertext, agentX25519Pub, agentSessionKey, err := AgentHandshake(hubKeys.MLKEMEncapKey, hubKeys.X25519PublicKey, "agent-1")
+	if err != nil {
+		t.Fatalf("AgentHandshake: %v", err)
+	}
+
+	hubSessionKey, err := HubDeriveSessionKey(hubKeys, mlkemCiphertext, agentX25519Pub, "agent-1")
+	if err != nil {
+		t.Fatalf("HubDeriveSessionKey: %v", err)
+	}
+
+	if subtle.ConstantTimeCompare(agentSessionKey, hubSessionKey) != 1 {
+		t.Fatal("agent and hub derived different session keys")
+	}
+}
+
+func TestHandshakeDifferentAgentIDs(t *testing.T) {
+	hubKeys, _ := GenerateHubKeys()
+	mlkemCiphertext, agentX25519Pub, agentKey, _ := AgentHandshake(hubKeys.MLKEMEncapKey, hubKeys.X25519PublicKey, "agent-A")
+	hubKey, _ := HubDeriveSessionKey(hubKeys, mlkemCiphertext, agentX25519Pub, "agent-B")
+
+	if bytes.Equal(agentKey, hubKey) {
+		t.Fatal("expected different keys for different agentIDs")
+	}
+}
+
+// ML-KEM uses implicit rejection: a corrupt ciphertext does not return an error —
+// it produces a wrong (pseudo-random) shared secret. The session mismatch is only
+// detectable when the AEGIS-256 authentication tag fails on the first encrypted message.
+// This test verifies that a corrupt ciphertext produces a different session key.
+func TestHandshakeCorruptCiphertextProducesDifferentKey(t *testing.T) {
+	hubKeys, _ := GenerateHubKeys()
+	mlkemCiphertext, agentX25519Pub, agentKey, _ := AgentHandshake(hubKeys.MLKEMEncapKey, hubKeys.X25519PublicKey, "agent-1")
+
+	corruptedCiphertext := make([]byte, len(mlkemCiphertext))
+	copy(corruptedCiphertext, mlkemCiphertext)
+	corruptedCiphertext[0] ^= 0xFF
+
+	hubKey, err := HubDeriveSessionKey(hubKeys, corruptedCiphertext, agentX25519Pub, "agent-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bytes.Equal(agentKey, hubKey) {
+		t.Fatal("corrupt ciphertext should produce a different session key (implicit rejection)")
+	}
+}
+
+func TestGenerateHubKeys_KeySizes(t *testing.T) {
+	keys, err := GenerateHubKeys()
+	if err != nil {
+		t.Fatalf("GenerateHubKeys: %v", err)
+	}
+	if len(keys.MLKEMEncapKey) != 1184 {
+		t.Errorf("MLKEMEncapKey: got %d bytes, want 1184", len(keys.MLKEMEncapKey))
+	}
+	if len(keys.X25519PublicKey) != 32 {
+		t.Errorf("X25519PublicKey: got %d bytes, want 32", len(keys.X25519PublicKey))
+	}
+}
+
+func TestHandshakeSessionKeyLength(t *testing.T) {
+	hubKeys, _ := GenerateHubKeys()
+	mlkemCiphertext, agentX25519Pub, sessionKey, _ := AgentHandshake(hubKeys.MLKEMEncapKey, hubKeys.X25519PublicKey, "agent-1")
+	if len(sessionKey) != 32 {
+		t.Errorf("agentSessionKey: got %d bytes, want 32", len(sessionKey))
+	}
+	hubKey, _ := HubDeriveSessionKey(hubKeys, mlkemCiphertext, agentX25519Pub, "agent-1")
+	if len(hubKey) != 32 {
+		t.Errorf("hubSessionKey: got %d bytes, want 32", len(hubKey))
+	}
+}

--- a/backend/internal/shared/wscrypto/handshake_test.go
+++ b/backend/internal/shared/wscrypto/handshake_test.go
@@ -82,3 +82,52 @@ func TestHandshakeSessionKeyLength(t *testing.T) {
 		t.Errorf("hubSessionKey: got %d bytes, want 32", len(hubKey))
 	}
 }
+
+func TestAgentHandshake_InvalidMLKEMKey(t *testing.T) {
+	_, _, _, err := AgentHandshake([]byte("not-a-valid-mlkem-key"), make([]byte, 32), "agent-1")
+	if err == nil {
+		t.Fatal("expected error for invalid ML-KEM encapsulation key")
+	}
+}
+
+func TestAgentHandshake_InvalidX25519Key(t *testing.T) {
+	hubKeys, err := GenerateHubKeys()
+	if err != nil {
+		t.Fatalf("GenerateHubKeys: %v", err)
+	}
+	_, _, _, err = AgentHandshake(hubKeys.MLKEMEncapKey, []byte("not-a-valid-x25519-key"), "agent-1")
+	if err == nil {
+		t.Fatal("expected error for invalid X25519 public key")
+	}
+}
+
+func TestHubDeriveSessionKey_InvalidCiphertextSize(t *testing.T) {
+	hubKeys, err := GenerateHubKeys()
+	if err != nil {
+		t.Fatalf("GenerateHubKeys: %v", err)
+	}
+	_, agentX25519Pub, _, err := AgentHandshake(hubKeys.MLKEMEncapKey, hubKeys.X25519PublicKey, "agent-1")
+	if err != nil {
+		t.Fatalf("AgentHandshake: %v", err)
+	}
+	// ML-KEM-768 ciphertext must be exactly 1088 bytes; wrong size causes an error.
+	_, err = HubDeriveSessionKey(hubKeys, []byte("too-short-ciphertext"), agentX25519Pub, "agent-1")
+	if err == nil {
+		t.Fatal("expected error for wrong-size ML-KEM ciphertext")
+	}
+}
+
+func TestHubDeriveSessionKey_InvalidX25519Key(t *testing.T) {
+	hubKeys, err := GenerateHubKeys()
+	if err != nil {
+		t.Fatalf("GenerateHubKeys: %v", err)
+	}
+	mlkemCiphertext, _, _, err := AgentHandshake(hubKeys.MLKEMEncapKey, hubKeys.X25519PublicKey, "agent-1")
+	if err != nil {
+		t.Fatalf("AgentHandshake: %v", err)
+	}
+	_, err = HubDeriveSessionKey(hubKeys, mlkemCiphertext, []byte("not-a-valid-x25519-key"), "agent-1")
+	if err == nil {
+		t.Fatal("expected error for invalid agent X25519 public key")
+	}
+}

--- a/backend/internal/shared/wscrypto/session.go
+++ b/backend/internal/shared/wscrypto/session.go
@@ -1,0 +1,59 @@
+package wscrypto
+
+import (
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+
+	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"github.com/aegis-aead/go-libaegis/aegis256"
+	"google.golang.org/protobuf/proto"
+)
+
+// per-connection AEGIS-256 for encrypting/decrypting WS messages.
+type Session struct {
+	aead cipher.AEAD
+}
+
+func NewSession(sessionKey []byte) (*Session, error) {
+	aead, err := aegis256.New(sessionKey, 32)
+	if err != nil {
+		return nil, fmt.Errorf("aegis256 init: %w", err)
+	}
+	return &Session{aead: aead}, nil
+}
+
+func (s *Session) Encrypt(inner proto.Message) (*messages.EncryptedPayload, error) {
+	plaintext, err := proto.Marshal(inner)
+	if err != nil {
+		return nil, fmt.Errorf("marshal inner message: %w", err)
+	}
+
+	nonce := make([]byte, aegis256.NonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
+	ciphertext := s.aead.Seal(nil, nonce, plaintext, nil)
+
+	return &messages.EncryptedPayload{
+		Nonce:      nonce,
+		Ciphertext: ciphertext,
+	}, nil
+}
+
+func (s *Session) Decrypt(env *messages.EncryptedPayload, dst proto.Message) error {
+	if len(env.Nonce) != aegis256.NonceSize {
+		return fmt.Errorf("invalid nonce length: got %d, want %d", len(env.Nonce), aegis256.NonceSize)
+	}
+
+	plaintext, err := s.aead.Open(nil, env.Nonce, env.Ciphertext, nil)
+	if err != nil {
+		return fmt.Errorf("aegis256 open: %w", err)
+	}
+
+	if err := proto.Unmarshal(plaintext, dst); err != nil {
+		return fmt.Errorf("unmarshal decrypted message: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/shared/wscrypto/session_test.go
+++ b/backend/internal/shared/wscrypto/session_test.go
@@ -88,3 +88,21 @@ func TestDecryptInvalidNonceLength(t *testing.T) {
 		t.Fatal("expected error for invalid nonce length")
 	}
 }
+
+func TestNewSession_InvalidKeySize(t *testing.T) {
+	_, err := NewSession([]byte{0x01, 0x02}) // too short, aegis256 requires 32 bytes
+	if err == nil {
+		t.Fatal("expected error for invalid key size")
+	}
+}
+
+func TestDecrypt_InvalidProtoBytes(t *testing.T) {
+	s := newTestSession(t)
+	nonce := make([]byte, 32) // aegis256.NonceSize == 32
+	invalidProto := []byte{0xFF, 0xFF, 0xFF}
+	ct := s.aead.Seal(nil, nonce, invalidProto, nil)
+	env := &messages.EncryptedPayload{Nonce: nonce, Ciphertext: ct}
+	if err := s.Decrypt(env, &messages.PingRequest{}); err == nil {
+		t.Fatal("expected error when decrypted bytes are not valid protobuf")
+	}
+}

--- a/backend/internal/shared/wscrypto/session_test.go
+++ b/backend/internal/shared/wscrypto/session_test.go
@@ -1,0 +1,90 @@
+package wscrypto
+
+import (
+	"bytes"
+	"testing"
+
+	messages "github.com/OrcaCD/orca-cd/internal/proto"
+)
+
+func newTestSession(t *testing.T) *Session {
+	t.Helper()
+	key := make([]byte, 32)
+	s, err := NewSession(key)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	return s
+}
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	s := newTestSession(t)
+
+	inner := &messages.ServerMessage{
+		Payload: &messages.ServerMessage_Ping{
+			Ping: &messages.PingRequest{Timestamp: 12345},
+		},
+	}
+
+	env, err := s.Encrypt(inner)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	dst := &messages.ServerMessage{}
+	if err := s.Decrypt(env, dst); err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+
+	ping, ok := dst.Payload.(*messages.ServerMessage_Ping)
+	if !ok {
+		t.Fatal("unexpected payload type after decrypt")
+	}
+	if ping.Ping.Timestamp != 12345 {
+		t.Errorf("timestamp: got %d, want 12345", ping.Ping.Timestamp)
+	}
+}
+
+func TestDecryptWrongNonce(t *testing.T) {
+	s := newTestSession(t)
+	env, _ := s.Encrypt(&messages.PingRequest{Timestamp: 1})
+	env.Nonce[0] ^= 0xFF
+	if err := s.Decrypt(env, &messages.PingRequest{}); err == nil {
+		t.Fatal("expected error for wrong nonce")
+	}
+}
+
+func TestDecryptCorruptCiphertext(t *testing.T) {
+	s := newTestSession(t)
+	env, _ := s.Encrypt(&messages.PingRequest{Timestamp: 1})
+	env.Ciphertext[0] ^= 0xFF
+	if err := s.Decrypt(env, &messages.PingRequest{}); err == nil {
+		t.Fatal("expected error for corrupt ciphertext")
+	}
+}
+
+func TestEncryptUniqueCiphertexts(t *testing.T) {
+	s := newTestSession(t)
+	msg := &messages.PingRequest{Timestamp: 42}
+
+	env1, _ := s.Encrypt(msg)
+	env2, _ := s.Encrypt(msg)
+
+	if bytes.Equal(env1.Ciphertext, env2.Ciphertext) {
+		t.Fatal("expected unique ciphertexts per encryption (random nonce)")
+	}
+	if bytes.Equal(env1.Nonce, env2.Nonce) {
+		t.Fatal("expected unique nonces per encryption")
+	}
+}
+
+func TestDecryptInvalidNonceLength(t *testing.T) {
+	s := newTestSession(t)
+	env := &messages.EncryptedPayload{
+		Nonce:      []byte{0x00},
+		Ciphertext: []byte{0x00},
+	}
+	if err := s.Decrypt(env, &messages.PingRequest{}); err == nil {
+		t.Fatal("expected error for invalid nonce length")
+	}
+}


### PR DESCRIPTION
## **Type of change**

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] ❓ Other (please specify)

## **Description**

Add an additional post-quantum safe encryption to Websocket messages. This also prevents messages from being read behind a proxy which does TLS termination or uses old / weak TLS configuration.
