### PR TITLE
feat: Add SSRF protection

### DIFF
--- a/backend/.env.dev.example
+++ b/backend/.env.dev.example
@@ -6,6 +6,7 @@ PORT=8080
 HOST=127.0.0.1
 APP_SECRET=
 DISABLE_UI=true
+ALLOWED_INTERNAL_IPS=
 
 # Agent
 HUB_URL=http://localhost:8080/

--- a/backend/internal/hub/oidc/oidc.go
+++ b/backend/internal/hub/oidc/oidc.go
@@ -107,10 +107,14 @@ func decryptState(encrypted string) (*stateData, error) {
 	return &sd, nil
 }
 
+// oidcHTTPClient is the HTTP client used for OIDC provider discovery and token
+// exchange. Replaced with an unrestricted client in tests.
+var oidcHTTPClient = httpclient.Default
+
 // oidcContext injects the shared HTTP client into ctx so that go-oidc and
 // oauth2 use it for all outbound requests (discovery, token exchange, etc.).
 func oidcContext(ctx context.Context) context.Context {
-	return gooidc.ClientContext(ctx, httpclient.Default)
+	return gooidc.ClientContext(ctx, oidcHTTPClient)
 }
 
 func StartAuth(ctx context.Context, provider *models.OIDCProvider, appURL string) (authURL string, encryptedState string, err error) {

--- a/backend/internal/hub/oidc/oidc_test.go
+++ b/backend/internal/hub/oidc/oidc_test.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +20,13 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/oauth2"
 )
+
+func TestMain(m *testing.M) {
+	// Tests spin up local httptest servers; swap in an unrestricted client so
+	// the SSRF-safe production client does not block 127.0.0.1.
+	oidcHTTPClient = http.DefaultClient
+	os.Exit(m.Run())
+}
 
 func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")

--- a/backend/internal/shared/httpclient/allowlist.go
+++ b/backend/internal/shared/httpclient/allowlist.go
@@ -1,0 +1,62 @@
+package httpclient
+
+import (
+	"net/netip"
+	"os"
+	"slices"
+	"strings"
+)
+
+var allowedInternalAddrs []netip.Addr
+var allowedInternalPrefixes []netip.Prefix
+
+func init() {
+	parseAllowedInternalIPs(os.Getenv("ALLOWED_INTERNAL_IPS"))
+}
+
+func parseAllowedInternalIPs(raw string) {
+	allowedInternalAddrs = nil
+	allowedInternalPrefixes = nil
+	if raw == "" {
+		return
+	}
+	for entry := range strings.SplitSeq(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if strings.Contains(entry, "/") {
+			prefix, err := netip.ParsePrefix(entry)
+			if err == nil {
+				allowedInternalPrefixes = append(allowedInternalPrefixes, prefix.Masked())
+			}
+		} else {
+			addr, err := ParseIP(entry)
+			if err == nil {
+				allowedInternalAddrs = append(allowedInternalAddrs, addr)
+			}
+		}
+	}
+}
+
+func isInternalIPAllowed(ip string) bool {
+	if len(allowedInternalAddrs) == 0 && len(allowedInternalPrefixes) == 0 {
+		return false
+	}
+
+	addr, err := ParseIP(ip)
+	if err != nil {
+		return false
+	}
+
+	if slices.Contains(allowedInternalAddrs, addr) {
+		return true
+	}
+
+	for _, p := range allowedInternalPrefixes {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/shared/httpclient/dialer.go
+++ b/backend/internal/shared/httpclient/dialer.go
@@ -1,0 +1,23 @@
+package httpclient
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+	"time"
+)
+
+var dialer = &net.Dialer{
+	Timeout:   30 * time.Second,
+	KeepAlive: 30 * time.Second,
+	Control: func(network, address string, c syscall.RawConn) error {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return err
+		}
+		if host != "" && IsPrivateIP(host) && !isInternalIPAllowed(host) {
+			return fmt.Errorf("SSRF detected: connection to %s is prohibited", host)
+		}
+		return nil
+	},
+}

--- a/backend/internal/shared/httpclient/httpclient.go
+++ b/backend/internal/shared/httpclient/httpclient.go
@@ -2,6 +2,8 @@ package httpclient
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -11,8 +13,30 @@ import (
 
 const DefaultTimeout = 15 * time.Second
 
+var safeTransport = &http.Transport{
+	DialContext:           dialer.DialContext,
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 2 * time.Second,
+}
+
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	host := req.URL.Hostname()
+	if IsPrivateIP(host) && !isInternalIPAllowed(host) {
+		return fmt.Errorf("SSRF detected: redirect to %s is prohibited", host)
+	}
+	return nil
+}
+
 var Default = &http.Client{
-	Timeout: DefaultTimeout,
+	Timeout:       DefaultTimeout,
+	Transport:     safeTransport,
+	CheckRedirect: checkRedirect,
 }
 
 func UserAgent() string {

--- a/backend/internal/shared/httpclient/httpclient.go
+++ b/backend/internal/shared/httpclient/httpclient.go
@@ -13,14 +13,16 @@ import (
 
 const DefaultTimeout = 15 * time.Second
 
-var safeTransport = &http.Transport{
-	DialContext:           dialer.DialContext,
-	ForceAttemptHTTP2:     true,
-	MaxIdleConns:          100,
-	IdleConnTimeout:       90 * time.Second,
-	TLSHandshakeTimeout:   10 * time.Second,
-	ExpectContinueTimeout: 2 * time.Second,
-}
+var safeTransport = func() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = dialer.DialContext
+	transport.ForceAttemptHTTP2 = true
+	transport.MaxIdleConns = 100
+	transport.IdleConnTimeout = 90 * time.Second
+	transport.TLSHandshakeTimeout = 10 * time.Second
+	transport.ExpectContinueTimeout = 2 * time.Second
+	return transport
+}()
 
 func checkRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) >= 10 {

--- a/backend/internal/shared/httpclient/httpclient_test.go
+++ b/backend/internal/shared/httpclient/httpclient_test.go
@@ -209,7 +209,10 @@ func TestGet_BlocksNipIODNSRebinding(t *testing.T) {
 func TestGet_BlocksSSRFViaRedirect(t *testing.T) {
 	resp, err := Get(context.Background(), "http://ssrf-redirects.testssandbox.com/ssrf-test")
 	if err == nil {
-		resp.Body.Close()
+		err := resp.Body.Close()
+		if err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
 		t.Fatal("expected SSRF error for redirect to 127.0.0.1, got nil")
 	}
 	if !strings.Contains(err.Error(), "SSRF") {
@@ -220,7 +223,10 @@ func TestGet_BlocksSSRFViaRedirect(t *testing.T) {
 func TestGet_BlocksSSRFViaIPv6RedirectChain(t *testing.T) {
 	resp, err := Get(context.Background(), "http://ssrf-redirects.testssandbox.com/ssrf-test-ipv6-twice")
 	if err == nil {
-		resp.Body.Close()
+		err := resp.Body.Close()
+		if err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
 		t.Fatal("expected SSRF error for redirect chain ending at [::1], got nil")
 	}
 	if !strings.Contains(err.Error(), "SSRF") {
@@ -295,7 +301,10 @@ func TestGet_AllowsAllowlistedLocalhostIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected successful response for allow-listed IP, got: %v", err)
 	}
-	resp.Body.Close()
+	err = resp.Body.Close()
+	if err != nil {
+		t.Errorf("failed to close response body: %v", err)
+	}
 }
 
 func TestCheckRedirect_AllowsAllowlistedPrivateIP(t *testing.T) {

--- a/backend/internal/shared/httpclient/httpclient_test.go
+++ b/backend/internal/shared/httpclient/httpclient_test.go
@@ -320,6 +320,35 @@ func TestCheckRedirect_AllowsAllowlistedPrivateIP(t *testing.T) {
 	}
 }
 
+func TestIsPrivateIP_ZoneQualifiedIPv6(t *testing.T) {
+	cases := []string{
+		"fe80::1%eth0",
+		"fe80::1%lo",
+		"fe80::dead:beef%en0",
+	}
+	for _, ip := range cases {
+		if !IsPrivateIP(ip) {
+			t.Errorf("expected zone-qualified link-local %q to be private", ip)
+		}
+	}
+}
+
+func TestCheckRedirect_BlocksZoneQualifiedIPv6(t *testing.T) {
+	cases := []string{
+		"http://[fe80::1%25eth0]/",
+		"http://[fe80::dead:beef%25lo]/secret",
+	}
+	for _, u := range cases {
+		req, err := http.NewRequest(http.MethodGet, u, nil)
+		if err != nil {
+			t.Fatalf("failed to build request for %s: %v", u, err)
+		}
+		if err := checkRedirect(req, nil); err == nil {
+			t.Errorf("expected SSRF error for redirect to zone-qualified IPv6 %s, got nil", u)
+		}
+	}
+}
+
 func TestCheckRedirect_LimitsRedirects(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "https://orcacd.dev/", nil)
 	if err != nil {

--- a/backend/internal/shared/httpclient/httpclient_test.go
+++ b/backend/internal/shared/httpclient/httpclient_test.go
@@ -16,6 +16,12 @@ func TestDefaultClient(t *testing.T) {
 	if Default.Timeout != DefaultTimeout {
 		t.Errorf("expected timeout %v, got %v", DefaultTimeout, Default.Timeout)
 	}
+	if Default.Transport == nil {
+		t.Error("expected custom transport, got nil")
+	}
+	if Default.CheckRedirect == nil {
+		t.Error("expected CheckRedirect to be set")
+	}
 }
 
 func TestDefaultTimeout(t *testing.T) {
@@ -32,7 +38,7 @@ func TestUserAgent(t *testing.T) {
 }
 
 func TestNewRequest_SetsUserAgent(t *testing.T) {
-	req, err := NewRequest(context.Background(), http.MethodGet, "http://example.com", nil)
+	req, err := NewRequest(context.Background(), http.MethodGet, "https://orcacd.dev/", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -43,7 +49,7 @@ func TestNewRequest_SetsUserAgent(t *testing.T) {
 
 func TestNewRequest_SetsMethod(t *testing.T) {
 	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodDelete} {
-		req, err := NewRequest(context.Background(), method, "http://example.com", nil)
+		req, err := NewRequest(context.Background(), method, "https://orcacd.dev/", nil)
 		if err != nil {
 			t.Fatalf("unexpected error for method %s: %v", method, err)
 		}
@@ -57,7 +63,7 @@ func TestNewRequest_UsesContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	req, err := NewRequest(ctx, http.MethodGet, "http://example.com", nil)
+	req, err := NewRequest(ctx, http.MethodGet, "https://orcacd.dev/", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -75,7 +81,7 @@ func TestNewRequest_InvalidURL(t *testing.T) {
 
 func TestNewRequest_WithBody(t *testing.T) {
 	body := strings.NewReader(`{"key":"value"}`)
-	req, err := NewRequest(context.Background(), http.MethodPost, "http://example.com", body)
+	req, err := NewRequest(context.Background(), http.MethodPost, "https://orcacd.dev", body)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -84,30 +90,23 @@ func TestNewRequest_WithBody(t *testing.T) {
 	}
 }
 
-func TestGet_SendsRequest(t *testing.T) {
-	var receivedUA string
+func TestGet_BlocksSSRFToLocalhost(t *testing.T) {
+	// httptest.NewServer binds to 127.0.0.1, which the SSRF-safe dialer must reject.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedUA = r.Header.Get("User-Agent")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
 	resp, err := Get(context.Background(), server.URL)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	defer func() {
+	if err == nil {
 		err := resp.Body.Close()
 		if err != nil {
 			t.Errorf("failed to close response body: %v", err)
 		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("expected 200, got %d", resp.StatusCode)
+		t.Fatal("expected SSRF error connecting to localhost, got nil")
 	}
-	if receivedUA != UserAgent() {
-		t.Errorf("expected User-Agent %q, got %q", UserAgent(), receivedUA)
+	if !strings.Contains(err.Error(), "SSRF") {
+		t.Errorf("expected SSRF error, got: %v", err)
 	}
 }
 
@@ -145,5 +144,180 @@ func TestGet_InvalidURL(t *testing.T) {
 			t.Errorf("failed to close response body: %v", err)
 		}
 		t.Error("expected nil response for invalid URL")
+	}
+}
+
+func TestCheckRedirect_BlocksPrivateIPLiteral(t *testing.T) {
+	privateURLs := []string{
+		"http://127.0.0.1/",
+		"http://192.168.1.1/secret",
+		"http://10.0.0.1/",
+		"https://10.0.0.8/",
+		"http://[::1]/",
+		"http://[fc00::1]/",
+		"https://[::ffff:192.168.2.1]/",
+	}
+	for _, u := range privateURLs {
+		req, err := http.NewRequest(http.MethodGet, u, nil)
+		if err != nil {
+			t.Fatalf("failed to build request for %s: %v", u, err)
+		}
+		if err := checkRedirect(req, nil); err == nil {
+			t.Errorf("expected SSRF error for redirect to %s, got nil", u)
+		}
+	}
+}
+
+func TestCheckRedirect_AllowsPublicURL(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://orcacd.dev/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkRedirect(req, nil); err != nil {
+		t.Errorf("expected no error for public URL redirect, got: %v", err)
+	}
+}
+
+func TestGet_BlocksLocalhostHostname(t *testing.T) {
+	resp, err := Get(context.Background(), "http://localhost/")
+	if err == nil {
+		err := resp.Body.Close()
+		if err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+		t.Fatal("expected SSRF error connecting to localhost hostname, got nil")
+	}
+	if !strings.Contains(err.Error(), "SSRF") {
+		t.Errorf("expected SSRF error, got: %v", err)
+	}
+}
+
+func TestGet_BlocksNipIODNSRebinding(t *testing.T) {
+	resp, err := Get(context.Background(), "http://www.192.168.0.1.nip.io/")
+	if err == nil {
+		err := resp.Body.Close()
+		if err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+		t.Fatal("expected SSRF error for nip.io hostname resolving to private IP, got nil")
+	}
+	if !strings.Contains(err.Error(), "SSRF") {
+		t.Skipf("local DNS resolver blocked nip.io before SSRF check could run: %v", err)
+	}
+}
+
+func TestGet_BlocksSSRFViaRedirect(t *testing.T) {
+	resp, err := Get(context.Background(), "http://ssrf-redirects.testssandbox.com/ssrf-test")
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected SSRF error for redirect to 127.0.0.1, got nil")
+	}
+	if !strings.Contains(err.Error(), "SSRF") {
+		t.Errorf("expected SSRF error, got: %v", err)
+	}
+}
+
+func TestGet_BlocksSSRFViaIPv6RedirectChain(t *testing.T) {
+	resp, err := Get(context.Background(), "http://ssrf-redirects.testssandbox.com/ssrf-test-ipv6-twice")
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected SSRF error for redirect chain ending at [::1], got nil")
+	}
+	if !strings.Contains(err.Error(), "SSRF") {
+		t.Errorf("expected SSRF error, got: %v", err)
+	}
+}
+
+func TestParseAllowedInternalIPs_SingleIP(t *testing.T) {
+	parseAllowedInternalIPs("192.168.1.5")
+	t.Cleanup(func() { parseAllowedInternalIPs("") })
+
+	if !isInternalIPAllowed("192.168.1.5") {
+		t.Error("expected 192.168.1.5 to be allowed")
+	}
+	if isInternalIPAllowed("192.168.1.6") {
+		t.Error("expected 192.168.1.6 to be blocked")
+	}
+}
+
+func TestParseAllowedInternalIPs_CIDR(t *testing.T) {
+	parseAllowedInternalIPs("10.0.0.0/8")
+	t.Cleanup(func() { parseAllowedInternalIPs("") })
+
+	if !isInternalIPAllowed("10.1.2.3") {
+		t.Error("expected 10.1.2.3 to be allowed by 10.0.0.0/8")
+	}
+	if isInternalIPAllowed("192.168.1.1") {
+		t.Error("expected 192.168.1.1 to be blocked (not in allowed CIDR)")
+	}
+}
+
+func TestParseAllowedInternalIPs_MultipleEntries(t *testing.T) {
+	parseAllowedInternalIPs("127.0.0.1, 10.0.0.0/8, ::1")
+	t.Cleanup(func() { parseAllowedInternalIPs("") })
+
+	for _, ip := range []string{"127.0.0.1", "10.5.5.5", "::1"} {
+		if !isInternalIPAllowed(ip) {
+			t.Errorf("expected %s to be allowed", ip)
+		}
+	}
+	if isInternalIPAllowed("192.168.1.1") {
+		t.Error("expected 192.168.1.1 to be blocked")
+	}
+}
+
+func TestParseAllowedInternalIPs_Empty(t *testing.T) {
+	parseAllowedInternalIPs("")
+	if isInternalIPAllowed("127.0.0.1") {
+		t.Error("expected 127.0.0.1 to be blocked when allow-list is empty")
+	}
+}
+
+func TestParseAllowedInternalIPs_InvalidEntries(t *testing.T) {
+	parseAllowedInternalIPs("notanip, , 300.300.300.300")
+	t.Cleanup(func() { parseAllowedInternalIPs("") })
+
+	if len(allowedInternalAddrs) != 0 || len(allowedInternalPrefixes) != 0 {
+		t.Error("expected empty allow-list after all-invalid input")
+	}
+}
+
+func TestGet_AllowsAllowlistedLocalhostIP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	parseAllowedInternalIPs("127.0.0.1")
+	t.Cleanup(func() { parseAllowedInternalIPs("") })
+
+	resp, err := Get(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("expected successful response for allow-listed IP, got: %v", err)
+	}
+	resp.Body.Close()
+}
+
+func TestCheckRedirect_AllowsAllowlistedPrivateIP(t *testing.T) {
+	parseAllowedInternalIPs("192.168.1.1")
+	t.Cleanup(func() { parseAllowedInternalIPs("") })
+
+	req, err := http.NewRequest(http.MethodGet, "http://192.168.1.1/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkRedirect(req, nil); err != nil {
+		t.Errorf("expected allow-listed IP to pass redirect check, got: %v", err)
+	}
+}
+
+func TestCheckRedirect_LimitsRedirects(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://orcacd.dev/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	via := make([]*http.Request, 10)
+	if err := checkRedirect(req, via); err == nil {
+		t.Error("expected error after 10 redirects, got nil")
 	}
 }

--- a/backend/internal/shared/httpclient/private_ip.go
+++ b/backend/internal/shared/httpclient/private_ip.go
@@ -1,6 +1,9 @@
 package httpclient
 
-import "net/netip"
+import (
+	"net/netip"
+	"strings"
+)
 
 var privateIPRangesStr = []string{
 	"0.0.0.0/8",          // "This" network (RFC 1122)
@@ -32,16 +35,21 @@ var privateIPRangesStr = []string{
 	"3fff::/20",     // Documentation prefix (RFC 9637)
 }
 
-var privateIpRanges []netip.Prefix
+var privateIPRanges []netip.Prefix
 
 func init() {
 	for _, cidr := range privateIPRangesStr {
 		prefix := netip.MustParsePrefix(cidr)
-		privateIpRanges = append(privateIpRanges, prefix)
+		privateIPRanges = append(privateIPRanges, prefix)
 	}
 }
 
 func ParseIP(ip string) (netip.Addr, error) {
+	// Strip IPv6 zone identifier (e.g. "fe80::1%eth0" → "fe80::1").
+	if i := strings.IndexByte(ip, '%'); i != -1 {
+		ip = ip[:i]
+	}
+
 	result, err := netip.ParseAddr(ip)
 	if err != nil {
 		return netip.Addr{}, err
@@ -64,7 +72,7 @@ func IsPrivateIP(ip string) bool {
 		return false
 	}
 
-	for _, p := range privateIpRanges {
+	for _, p := range privateIPRanges {
 		if p.Contains(ipAddress) {
 			return true
 		}

--- a/backend/internal/shared/httpclient/private_ip.go
+++ b/backend/internal/shared/httpclient/private_ip.go
@@ -1,0 +1,74 @@
+package httpclient
+
+import "net/netip"
+
+var privateIPRangesStr = []string{
+	"0.0.0.0/8",          // "This" network (RFC 1122)
+	"10.0.0.0/8",         // Private-Use Networks (RFC 1918)
+	"127.0.0.0/8",        // Loopback (RFC 1122)
+	"192.168.0.0/16",     // Private-Use Networks (RFC 1918)
+	"172.16.0.0/12",      // Private-Use Networks (RFC 1918)
+	"100.64.0.0/10",      // Shared Address Space (RFC 6598)
+	"169.254.0.0/16",     // Link Local (RFC 3927)
+	"192.0.0.0/24",       // IETF Protocol Assignments (RFC 5736)
+	"192.0.2.0/24",       // TEST-NET-1 (RFC 5737)
+	"192.31.196.0/24",    // AS112 Redirection Anycast (RFC 7535)
+	"192.52.193.0/24",    // Automatic Multicast Tunneling (RFC 7450)
+	"192.88.99.0/24",     // 6to4 Relay Anycast (RFC 3068)
+	"192.175.48.0/24",    // AS112 Redirection Anycast (RFC 7535)
+	"198.18.0.0/15",      // Network Interconnect Device Benchmark Testing (RFC 2544)
+	"198.51.100.0/24",    // TEST-NET-2 (RFC 5737)
+	"203.0.113.0/24",     // TEST-NET-3 (RFC 5737)
+	"224.0.0.0/4",        // Multicast (RFC 3171)
+	"240.0.0.0/4",        // Reserved for Future Use (RFC 1112)
+	"255.255.255.255/32", // Limited Broadcast (RFC 919)
+
+	"::/128",        // Unspecified address (RFC 4291)
+	"::1/128",       // Loopback address (RFC 4291)
+	"fc00::/7",      // Unique local address (ULA) (RFC 4193)
+	"fe80::/10",     // Link-local address (LLA) (RFC 4291)
+	"100::/64",      // Discard prefix (RFC 6666)
+	"2001:db8::/32", // Documentation prefix (RFC 3849)
+	"3fff::/20",     // Documentation prefix (RFC 9637)
+}
+
+var privateIpRanges []netip.Prefix
+
+func init() {
+	for _, cidr := range privateIPRangesStr {
+		prefix := netip.MustParsePrefix(cidr)
+		privateIpRanges = append(privateIpRanges, prefix)
+	}
+}
+
+func ParseIP(ip string) (netip.Addr, error) {
+	result, err := netip.ParseAddr(ip)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+
+	if result.Is4In6() {
+		return result.Unmap(), nil
+	}
+
+	return result, nil
+}
+
+func IsPrivateIP(ip string) bool {
+	if ip == "" {
+		return false
+	}
+
+	ipAddress, err := ParseIP(ip)
+	if err != nil {
+		return false
+	}
+
+	for _, p := range privateIpRanges {
+		if p.Contains(ipAddress) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## **Type of change**

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] ❓ Other (please specify)

## **Description**

Protect the app against Server Side Request Forgery (SSRF) ([What is SSRF?](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/SSRF)). The env var `ALLOWED_INTERNAL_IPS` allows to bypass the protection for e.g. a locally hosted Git or OIDC service.