### PR TITLE
chore: Add cooldown to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     labels:
       - 'dependencies'
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 2
     groups:
       dependencies:
         patterns:
@@ -25,6 +27,8 @@ updates:
     labels:
       - 'dependencies'
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 2
     groups:
       dependencies:
         patterns:
@@ -40,6 +44,8 @@ updates:
     labels:
       - 'dependencies'
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 2
     groups:
       dependencies:
         patterns:
@@ -55,6 +61,8 @@ updates:
     labels:
       - 'dependencies'
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 2
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
To enhance security against supply chain attacks.