### PR TITLE
feat: Attest docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
       packages: write
       attestations: write
       id-token: write
+      artifact-metadata: write
     strategy:
       matrix:
         include:
@@ -111,6 +112,13 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: true
           sbom: true
+
+      - name: Attest ${{ matrix.name }} image
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       - name: Sign ${{ matrix.name }} image
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          provenance: true
+          provenance: mode=max
           sbom: true
 
       - name: Attest ${{ matrix.name }} image


### PR DESCRIPTION
## **Type of change**

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] ❓ Other (please specify)

## **Description**

The attestion from the docker/build-push-action (´provenance: true´) is generated by the docker BuildKit and is not in relation to the github attestions.

The added action will push an attestation to the github attestation page
https://github.com/OrcaCD/orca-cd/attestations
