### PR TITLE
fix: Cosign casing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,5 +122,6 @@ jobs:
 
       - name: Sign ${{ matrix.name }} image
         run: |
+          LOWERCASE_IMAGE_PREFIX=$(echo "$IMAGE_PREFIX" | tr '[:upper:]' '[:lower:]')
           cosign sign --yes \
-            ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}@${{ steps.build.outputs.digest }}
+            "$LOWERCASE_IMAGE_PREFIX/${{ matrix.name }}@${{ steps.build.outputs.digest }}"


### PR DESCRIPTION
## **Type of change**

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] ❓ Other (please specify)

## **Description**

https://github.com/OrcaCD/orca-cd/actions/runs/25597136389/job/75144960327

Cosign requires the username to be lowercase. Verified locally this works now
