### PR TITLE
fix: Image polling locking

### DIFF
--- a/backend/internal/agent/docker/image_poller.go
+++ b/backend/internal/agent/docker/image_poller.go
@@ -43,21 +43,23 @@ type appPollState struct {
 
 // ImagePoller manages per-application image polling tickers.
 type ImagePoller struct {
-	mu     sync.Mutex
-	log    zerolog.Logger
-	apps   map[string]*appPollState // keyed by applicationID
-	client *Client
-	sender MessageSender
+	mu       sync.Mutex
+	log      zerolog.Logger
+	apps     map[string]*appPollState // keyed by applicationID
+	runLocks map[string]*sync.Mutex
+	client   *Client
+	sender   MessageSender
 }
 
 // NewImagePoller creates a new ImagePoller. sender is used to report results to the hub;
 // SendMessage is a no-op when the agent is disconnected.
 func NewImagePoller(c *Client, sender MessageSender, log zerolog.Logger) *ImagePoller {
 	return &ImagePoller{
-		log:    log,
-		apps:   make(map[string]*appPollState),
-		client: c,
-		sender: sender,
+		log:      log,
+		apps:     make(map[string]*appPollState),
+		runLocks: make(map[string]*sync.Mutex),
+		client:   c,
+		sender:   sender,
 	}
 }
 
@@ -140,6 +142,10 @@ func (p *ImagePoller) runTicker(appID, appName string, settings PollSettings, st
 }
 
 func (p *ImagePoller) runOnce(appID, appName, requestID string) {
+	runLock := p.lockForRun(appID)
+	runLock.Lock()
+	defer runLock.Unlock()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
@@ -178,4 +184,16 @@ func (p *ImagePoller) runOnce(appID, appName, requestID string) {
 	}); sendErr != nil {
 		p.log.Error().Err(sendErr).Str("application_id", appID).Msg("image poll: failed to send result")
 	}
+}
+
+func (p *ImagePoller) lockForRun(appID string) *sync.Mutex {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	runLock, ok := p.runLocks[appID]
+	if !ok {
+		runLock = &sync.Mutex{}
+		p.runLocks[appID] = runLock
+	}
+	return runLock
 }

--- a/backend/internal/agent/docker/image_poller_test.go
+++ b/backend/internal/agent/docker/image_poller_test.go
@@ -324,3 +324,49 @@ func TestImagePoller_TriggerNow(t *testing.T) {
 		t.Fatal("timed out waiting for TriggerNow to call checkAndPullImages")
 	}
 }
+
+func TestImagePoller_TriggerNow_SerializesSameApplication(t *testing.T) {
+	origCheck := checkAndPullImages
+	t.Cleanup(func() { checkAndPullImages = origCheck })
+
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseAll := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	t.Cleanup(releaseAll)
+
+	checkAndPullImages = func(_ context.Context, _ *Client, _, _ string, _ bool) (bool, error) {
+		started <- struct{}{}
+		<-release
+		return false, nil
+	}
+
+	p := newTestPoller(t, nil)
+	p.TriggerNow("app-1", "billing", "req-1")
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first pull to start")
+	}
+
+	p.TriggerNow("app-1", "billing", "req-2")
+
+	select {
+	case <-started:
+		t.Fatal("second pull started while first pull was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseAll()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second pull to run after first completed")
+	}
+}


### PR DESCRIPTION
## **Type of change**

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] ❓ Other (please specify)

## **Description**

Image update webhooks were called multiple times and caused problems because image polling wasn't locked
