### PR TITLE
fix: support relative bind mounts from agent containers

### DIFF
--- a/backend/internal/agent/agent.go
+++ b/backend/internal/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -39,6 +40,7 @@ type Config struct {
 	HubPublicKey                  ed25519.PublicKey
 	HealthPort                    string
 	DeploymentsDir                string
+	HostDeploymentsDir            string
 	AllowedPrivilegedApps         map[string]struct{}
 	RestrictBindMountsToDeployDir bool
 }
@@ -83,6 +85,15 @@ func DefaultConfig() (Config, error) {
 		deploymentsDir = "/deployments"
 	}
 
+	hostDeploymentsDir := ""
+	if value, configured := os.LookupEnv("HOST_DEPLOYMENTS_DIR"); configured {
+		value = strings.TrimSpace(value)
+		if value == "" || !filepath.IsAbs(value) {
+			return Config{}, &FatalConfigError{Msg: "HOST_DEPLOYMENTS_DIR must be an absolute path on the Docker host"}
+		}
+		hostDeploymentsDir = filepath.Clean(value)
+	}
+
 	allowedPrivilegedApps := make(map[string]struct{})
 	for entry := range strings.SplitSeq(os.Getenv("ALLOWED_PRIVILEGED_APPS"), ",") {
 		if s := strings.TrimSpace(entry); s != "" {
@@ -101,6 +112,7 @@ func DefaultConfig() (Config, error) {
 		HubPublicKey:                  hubPublicKey,
 		HealthPort:                    healthPort,
 		DeploymentsDir:                deploymentsDir,
+		HostDeploymentsDir:            hostDeploymentsDir,
 		AllowedPrivilegedApps:         allowedPrivilegedApps,
 		RestrictBindMountsToDeployDir: restrictBindMountsToDeployDir,
 	}, nil
@@ -193,7 +205,7 @@ func Run(cfg Config) error {
 
 	Log.Info().Str("version", version.Version).Msg("agent started")
 
-	dockerClient, err := docker.New(Log, cfg.DeploymentsDir, cfg.AllowedPrivilegedApps, cfg.RestrictBindMountsToDeployDir)
+	dockerClient, err := docker.New(Log, cfg.DeploymentsDir, cfg.HostDeploymentsDir, cfg.AllowedPrivilegedApps, cfg.RestrictBindMountsToDeployDir)
 	if err != nil {
 		return fmt.Errorf("docker init: %w", err)
 	}

--- a/backend/internal/agent/agent_config_test.go
+++ b/backend/internal/agent/agent_config_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -37,6 +38,21 @@ func makeTestToken(t *testing.T, agentID string) (tokenStr string, hubPubKey ed2
 		t.Fatalf("sign token: %v", err)
 	}
 	return str, pub
+}
+
+func unsetTestEnv(t *testing.T, key string) {
+	t.Helper()
+	value, set := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if set {
+			_ = os.Setenv(key, value)
+			return
+		}
+		_ = os.Unsetenv(key)
+	})
 }
 
 func TestDefaultConfig_Valid(t *testing.T) {
@@ -77,6 +93,7 @@ func TestDefaultConfig_Valid(t *testing.T) {
 
 func TestDefaultConfig_Defaults(t *testing.T) {
 	token, _ := makeTestToken(t, "test-agent-id")
+	unsetTestEnv(t, "HOST_DEPLOYMENTS_DIR")
 	t.Setenv("HUB_URL", "https://hub.example.com")
 	t.Setenv("AUTH_TOKEN", token)
 	t.Setenv("LOG_LEVEL", "")
@@ -96,6 +113,41 @@ func TestDefaultConfig_Defaults(t *testing.T) {
 	}
 	if cfg.DeploymentsDir != "/deployments" {
 		t.Errorf("DeploymentsDir = %q, want %q", cfg.DeploymentsDir, "/deployments")
+	}
+	if cfg.HostDeploymentsDir != "" {
+		t.Errorf("HostDeploymentsDir = %q, want empty", cfg.HostDeploymentsDir)
+	}
+}
+
+func TestDefaultConfig_HostDeploymentsDir(t *testing.T) {
+	token, _ := makeTestToken(t, "test-agent-id")
+	t.Setenv("HUB_URL", "https://hub.example.com")
+	t.Setenv("AUTH_TOKEN", token)
+	t.Setenv("HOST_DEPLOYMENTS_DIR", "  /srv/orcacd/deployments/  ")
+
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	if cfg.HostDeploymentsDir != "/srv/orcacd/deployments" {
+		t.Errorf("HostDeploymentsDir = %q, want %q", cfg.HostDeploymentsDir, "/srv/orcacd/deployments")
+	}
+}
+
+func TestDefaultConfig_InvalidHostDeploymentsDir(t *testing.T) {
+	for _, value := range []string{"./deployments", "   "} {
+		t.Run(value, func(t *testing.T) {
+			token, _ := makeTestToken(t, "test-agent-id")
+			t.Setenv("HUB_URL", "https://hub.example.com")
+			t.Setenv("AUTH_TOKEN", token)
+			t.Setenv("HOST_DEPLOYMENTS_DIR", value)
+
+			_, err := DefaultConfig()
+			var configErr *FatalConfigError
+			if !errors.As(err, &configErr) {
+				t.Fatalf("expected FatalConfigError for %q, got %v", value, err)
+			}
+		})
 	}
 }
 

--- a/backend/internal/agent/docker/deploy.go
+++ b/backend/internal/agent/docker/deploy.go
@@ -126,11 +126,17 @@ func (c *Client) Deploy(ctx context.Context, req DeployRequest) error {
 	if err != nil {
 		return fmt.Errorf("load compose project: %w", err)
 	}
+	if err := translateBindMountSources(project, c.deploymentsDir, c.hostDeploymentsDir); err != nil {
+		return fmt.Errorf("translate bind mount sources: %w", err)
+	}
 
 	if _, allowed := c.allowedPrivilegedApps[req.ApplicationID]; !allowed {
 		restrictMountsDir := ""
 		if c.restrictMountsToDeployDir {
 			restrictMountsDir = c.deploymentsDir
+			if c.hostDeploymentsDir != "" {
+				restrictMountsDir = c.hostDeploymentsDir
+			}
 		}
 		if err := checkDeployPolicy(project, restrictMountsDir); err != nil {
 			return fmt.Errorf("deployment rejected by security policy: %w (add application id %q to ALLOWED_PRIVILEGED_APPS to bypass all security policy checks)", err, req.ApplicationID)

--- a/backend/internal/agent/docker/deploy_test.go
+++ b/backend/internal/agent/docker/deploy_test.go
@@ -331,6 +331,104 @@ func TestDeploy_RestrictMountsToDeployDirAllowsMountInsideDeploymentsDir(t *test
 	}
 }
 
+func TestDeploy_TranslatesBindMountForAllowlistedApplication(t *testing.T) {
+	const allowedAppID = "019e1ce8-7938-71b8-be55-4b184f307a2d"
+
+	c := newTestClientWithAllowlist(t, map[string]struct{}{allowedAppID: {}})
+	c.deploymentsDir = t.TempDir()
+	c.hostDeploymentsDir = "/srv/orca/deployments"
+	c.mu.Lock()
+	c.ready = true
+	c.mu.Unlock()
+
+	origLoad := loadProject
+	origUp := upProject
+	t.Cleanup(func() {
+		loadProject = origLoad
+		upProject = origUp
+	})
+	loadProject = func(_ context.Context, _ api.Compose, opts api.ProjectLoadOptions) (*composetypes.Project, error) {
+		return &composetypes.Project{
+			Name: opts.ProjectName,
+			Services: composetypes.Services{"app": composetypes.ServiceConfig{
+				Privileged: true,
+				Volumes: []composetypes.ServiceVolumeConfig{
+					{
+						Type:   composetypes.VolumeTypeBind,
+						Source: filepath.Join(c.deploymentsDir, "billing", "data"),
+						Target: "/data",
+					},
+				},
+			}},
+		}, nil
+	}
+	var gotSource string
+	upProject = func(_ context.Context, _ api.Compose, project *composetypes.Project, _ api.UpOptions) error {
+		gotSource = project.Services["app"].Volumes[0].Source
+		return nil
+	}
+
+	err := c.Deploy(t.Context(), DeployRequest{
+		ApplicationID:   allowedAppID,
+		ApplicationName: "billing",
+		ComposeFile:     "services:\n  app:\n    image: img:latest\n",
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if gotSource != "/srv/orca/deployments/billing/data" {
+		t.Errorf("bind source = %q, want %q", gotSource, "/srv/orca/deployments/billing/data")
+	}
+}
+
+func TestDeploy_RestrictMountsAllowsTranslatedDeploymentBind(t *testing.T) {
+	c := newTestClient(t)
+	c.deploymentsDir = t.TempDir()
+	c.hostDeploymentsDir = "/srv/orca/deployments"
+	c.restrictMountsToDeployDir = true
+	c.mu.Lock()
+	c.ready = true
+	c.mu.Unlock()
+
+	origLoad := loadProject
+	origUp := upProject
+	t.Cleanup(func() {
+		loadProject = origLoad
+		upProject = origUp
+	})
+	loadProject = func(_ context.Context, _ api.Compose, opts api.ProjectLoadOptions) (*composetypes.Project, error) {
+		return &composetypes.Project{
+			Name: opts.ProjectName,
+			Services: composetypes.Services{"app": composetypes.ServiceConfig{
+				Volumes: []composetypes.ServiceVolumeConfig{
+					{
+						Type:   composetypes.VolumeTypeBind,
+						Source: filepath.Join(c.deploymentsDir, "billing", "data"),
+						Target: "/data",
+					},
+				},
+			}},
+		}, nil
+	}
+	upCalled := false
+	upProject = func(_ context.Context, _ api.Compose, _ *composetypes.Project, _ api.UpOptions) error {
+		upCalled = true
+		return nil
+	}
+
+	err := c.Deploy(t.Context(), DeployRequest{
+		ApplicationID:   "019e1ce8-7938-71b8-be55-4b184f307a2d",
+		ApplicationName: "billing",
+		ComposeFile:     "services:\n  app:\n    image: img:latest\n",
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if !upCalled {
+		t.Fatal("expected compose up to be called")
+	}
+}
+
 func TestRemove_DownsProjectAndRemovesDir(t *testing.T) {
 	c := newTestClient(t)
 	c.deploymentsDir = t.TempDir()

--- a/backend/internal/agent/docker/docker.go
+++ b/backend/internal/agent/docker/docker.go
@@ -22,6 +22,7 @@ type Client struct {
 	cli                       command.Cli
 	compose                   api.Compose
 	deploymentsDir            string
+	hostDeploymentsDir        string
 	allowedPrivilegedApps     map[string]struct{}
 	restrictMountsToDeployDir bool
 	ready                     bool
@@ -29,7 +30,7 @@ type Client struct {
 	cancel                    context.CancelFunc
 }
 
-func New(log zerolog.Logger, deploymentsDir string, allowedPrivilegedApps map[string]struct{}, restrictMountsToDeployDir bool) (*Client, error) {
+func New(log zerolog.Logger, deploymentsDir, hostDeploymentsDir string, allowedPrivilegedApps map[string]struct{}, restrictMountsToDeployDir bool) (*Client, error) {
 	dockerCLI, err := command.NewDockerCli()
 	if err != nil {
 		return nil, err
@@ -50,6 +51,7 @@ func New(log zerolog.Logger, deploymentsDir string, allowedPrivilegedApps map[st
 		cli:                       dockerCLI,
 		compose:                   composeSvc,
 		deploymentsDir:            deploymentsDir,
+		hostDeploymentsDir:        hostDeploymentsDir,
 		allowedPrivilegedApps:     allowedPrivilegedApps,
 		restrictMountsToDeployDir: restrictMountsToDeployDir,
 		ctx:                       ctx,

--- a/backend/internal/agent/docker/docker_test.go
+++ b/backend/internal/agent/docker/docker_test.go
@@ -13,7 +13,7 @@ func newTestClient(t *testing.T) *Client {
 
 func newTestClientWithAllowlist(t *testing.T, allowedPrivilegedApps map[string]struct{}) *Client {
 	t.Helper()
-	c, err := New(zerolog.Nop(), t.TempDir(), allowedPrivilegedApps, false)
+	c, err := New(zerolog.Nop(), t.TempDir(), "", allowedPrivilegedApps, false)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestPingDaemon(t *testing.T) {
 func TestNew_DaemonUnreachable(t *testing.T) {
 	t.Setenv("DOCKER_HOST", "tcp://localhost:1")
 
-	c, err := New(zerolog.Nop(), t.TempDir(), nil, false)
+	c, err := New(zerolog.Nop(), t.TempDir(), "", nil, false)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestNew_DaemonUnreachable(t *testing.T) {
 func TestPingDaemon_Unreachable(t *testing.T) {
 	t.Setenv("DOCKER_HOST", "tcp://localhost:1")
 
-	c, err := New(zerolog.Nop(), t.TempDir(), nil, false)
+	c, err := New(zerolog.Nop(), t.TempDir(), "", nil, false)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/backend/internal/agent/docker/images.go
+++ b/backend/internal/agent/docker/images.go
@@ -79,6 +79,9 @@ func (c *Client) CheckAndPullImages(ctx context.Context, appID, appName string, 
 	if err != nil {
 		return false, fmt.Errorf("load compose project: %w", err)
 	}
+	if err := translateBindMountSources(project, c.deploymentsDir, c.hostDeploymentsDir); err != nil {
+		return false, fmt.Errorf("translate bind mount sources: %w", err)
+	}
 
 	dockerCLI := c.cli.Client()
 

--- a/backend/internal/agent/docker/images_test.go
+++ b/backend/internal/agent/docker/images_test.go
@@ -209,6 +209,60 @@ func TestCheckAndPullImages_StaleImages(t *testing.T) {
 	}
 }
 
+func TestCheckAndPullImages_TranslatesBindMountBeforeUp(t *testing.T) {
+	saveRestoreVars(t)
+	c := newTestClient(t)
+	c.deploymentsDir = t.TempDir()
+	c.hostDeploymentsDir = "/srv/orca/deployments"
+
+	appDir := filepath.Join(c.deploymentsDir, "billing")
+	if err := os.MkdirAll(appDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, composeFileName), []byte("services:\n  app:\n    image: ghcr.io/org/app:latest\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	loadProject = func(_ context.Context, _ api.Compose, _ api.ProjectLoadOptions) (*composetypes.Project, error) {
+		project := makeProject("ghcr.io/org/app:latest")
+		service := project.Services["a"]
+		service.Volumes = []composetypes.ServiceVolumeConfig{
+			{
+				Type:   composetypes.VolumeTypeBind,
+				Source: filepath.Join(appDir, "data"),
+				Target: "/data",
+			},
+		}
+		project.Services["a"] = service
+		return project, nil
+	}
+	getRemoteDigest = func(_ context.Context, _ command.Cli, _ string) (string, error) {
+		return "sha256:newdigest", nil
+	}
+	getLocalDigests = func(_ context.Context, _ client.APIClient, _ string) ([]string, error) {
+		return []string{"ghcr.io/org/app@sha256:olddigest"}, nil
+	}
+	pullProject = func(_ context.Context, _ api.Compose, _ *composetypes.Project, _ api.PullOptions) error {
+		return nil
+	}
+	var gotSource string
+	upProject = func(_ context.Context, _ api.Compose, project *composetypes.Project, _ api.UpOptions) error {
+		gotSource = project.Services["a"].Volumes[0].Source
+		return nil
+	}
+
+	updated, err := c.CheckAndPullImages(t.Context(), "app-123", "billing", false)
+	if err != nil {
+		t.Fatalf("CheckAndPullImages: %v", err)
+	}
+	if !updated {
+		t.Fatal("expected stale image to be updated")
+	}
+	if gotSource != "/srv/orca/deployments/billing/data" {
+		t.Errorf("bind source = %q, want %q", gotSource, "/srv/orca/deployments/billing/data")
+	}
+}
+
 func TestCheckAndPullImages_OrcaLabelsAppliedBeforeUp(t *testing.T) {
 	saveRestoreVars(t)
 	c := newTestClient(t)

--- a/backend/internal/agent/docker/mounts.go
+++ b/backend/internal/agent/docker/mounts.go
@@ -1,0 +1,46 @@
+package docker
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	composetypes "github.com/compose-spec/compose-go/v2/types"
+)
+
+func translateBindMountSources(project *composetypes.Project, deploymentsDir, hostDeploymentsDir string) error {
+	if hostDeploymentsDir == "" {
+		return nil
+	}
+
+	agentBase, err := filepath.Abs(deploymentsDir)
+	if err != nil {
+		return fmt.Errorf("resolve deployments directory: %w", err)
+	}
+	hostBase := filepath.Clean(hostDeploymentsDir)
+
+	for serviceName, service := range project.Services {
+		for i, volume := range service.Volumes {
+			if volume.Type != composetypes.VolumeTypeBind {
+				continue
+			}
+
+			source := volume.Source
+			if !filepath.IsAbs(source) {
+				source = filepath.Join(agentBase, source)
+			}
+			rel, err := filepath.Rel(agentBase, filepath.Clean(source))
+			if err != nil {
+				return fmt.Errorf("service %q: resolve bind mount source %q: %w", serviceName, volume.Source, err)
+			}
+			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				continue
+			}
+
+			service.Volumes[i].Source = filepath.Join(hostBase, rel)
+		}
+		project.Services[serviceName] = service
+	}
+
+	return nil
+}

--- a/backend/internal/agent/docker/mounts_test.go
+++ b/backend/internal/agent/docker/mounts_test.go
@@ -1,0 +1,85 @@
+package docker
+
+import (
+	"testing"
+
+	composetypes "github.com/compose-spec/compose-go/v2/types"
+)
+
+func TestTranslateBindMountSources_TranslatesDeploymentBindMount(t *testing.T) {
+	project := &composetypes.Project{Services: composetypes.Services{
+		"app": composetypes.ServiceConfig{Volumes: []composetypes.ServiceVolumeConfig{
+			{
+				Type:     composetypes.VolumeTypeBind,
+				Source:   "/deployments/app/data",
+				Target:   "/data",
+				ReadOnly: true,
+				Bind:     &composetypes.ServiceVolumeBind{CreateHostPath: true},
+			},
+			{Type: composetypes.VolumeTypeVolume, Source: "cache", Target: "/cache"},
+		}},
+	}}
+
+	if err := translateBindMountSources(project, "/deployments", "/srv/orca/deployments"); err != nil {
+		t.Fatalf("translateBindMountSources: %v", err)
+	}
+
+	volumes := project.Services["app"].Volumes
+	if volumes[0].Source != "/srv/orca/deployments/app/data" {
+		t.Errorf("bind source = %q, want %q", volumes[0].Source, "/srv/orca/deployments/app/data")
+	}
+	if volumes[0].Target != "/data" || !volumes[0].ReadOnly || !bool(volumes[0].Bind.CreateHostPath) {
+		t.Errorf("bind mount options changed: %#v", volumes[0])
+	}
+	if volumes[1].Source != "cache" || volumes[1].Type != composetypes.VolumeTypeVolume {
+		t.Errorf("named volume changed: %#v", volumes[1])
+	}
+}
+
+func TestTranslateBindMountSources_TranslatesDeploymentRoot(t *testing.T) {
+	project := projectWithBindMount("/deployments")
+
+	if err := translateBindMountSources(project, "/deployments", "/srv/orca/deployments"); err != nil {
+		t.Fatalf("translateBindMountSources: %v", err)
+	}
+
+	if got := project.Services["app"].Volumes[0].Source; got != "/srv/orca/deployments" {
+		t.Errorf("bind source = %q, want %q", got, "/srv/orca/deployments")
+	}
+}
+
+func TestTranslateBindMountSources_LeavesExternalSourcesUnchanged(t *testing.T) {
+	for _, source := range []string{"/srv/shared", "/deployments-old/app/data"} {
+		t.Run(source, func(t *testing.T) {
+			project := projectWithBindMount(source)
+
+			if err := translateBindMountSources(project, "/deployments", "/srv/orca/deployments"); err != nil {
+				t.Fatalf("translateBindMountSources: %v", err)
+			}
+
+			if got := project.Services["app"].Volumes[0].Source; got != source {
+				t.Errorf("bind source = %q, want unchanged %q", got, source)
+			}
+		})
+	}
+}
+
+func TestTranslateBindMountSources_NoHostMappingIsNoOp(t *testing.T) {
+	project := projectWithBindMount("/deployments/app/data")
+
+	if err := translateBindMountSources(project, "/deployments", ""); err != nil {
+		t.Fatalf("translateBindMountSources: %v", err)
+	}
+
+	if got := project.Services["app"].Volumes[0].Source; got != "/deployments/app/data" {
+		t.Errorf("bind source = %q, want unchanged", got)
+	}
+}
+
+func projectWithBindMount(source string) *composetypes.Project {
+	return &composetypes.Project{Services: composetypes.Services{
+		"app": composetypes.ServiceConfig{Volumes: []composetypes.ServiceVolumeConfig{
+			{Type: composetypes.VolumeTypeBind, Source: source, Target: "/data"},
+		}},
+	}}
+}

--- a/backend/internal/agent/docker/status_test.go
+++ b/backend/internal/agent/docker/status_test.go
@@ -20,7 +20,7 @@ func TestApplicationHealth_NoContainersIsUnknown(t *testing.T) {
 func TestApplicationHealth_DaemonUnreachableIsUnknown(t *testing.T) {
 	t.Setenv("DOCKER_HOST", "tcp://localhost:1")
 
-	c, err := New(zerolog.Nop(), t.TempDir(), nil, false)
+	c, err := New(zerolog.Nop(), t.TempDir(), "", nil, false)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,6 +27,7 @@ services:
     environment:
       - HUB_URL=ws://hub:8080/api/v1/ws
       - AUTH_TOKEN=
+      - HOST_DEPLOYMENTS_DIR=${PWD}/data/agent/deployments # Run Compose from this file's directory
 
   pocket-id:
     container_name: pocket-id-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     container_name: orca-agent
     restart: unless-stopped
     env_file: .env
+    environment:
+      HOST_DEPLOYMENTS_DIR: ${PWD}/deployments # Run Compose from this file's directory
     security_opt:
       - no-new-privileges:true
     cap_drop:


### PR DESCRIPTION
## Summary

- add optional `HOST_DEPLOYMENTS_DIR` configuration for host-visible deployment paths
- translate deployment-local bind mount sources before deploys and image-update redeploys
- keep bind-mount restrictions aligned with the translated host path
- document the setting in the production and development Compose examples

## Root cause

Compose resolves relative bind mount sources inside the OrcaCD agent container, for example to `/deployments/<app>/data`. The Docker daemon runs on the host and interprets bind sources in the host filesystem, so that container-internal path is not valid there.

## Impact

Applications can use convenient relative mounts such as `./data:/app/data` while their files remain directly accessible on the host below the configured deployment directory.

## Validation

- `go test -race ./internal/agent -count=1`
- `go test -race ./internal/agent/docker -run 'TranslateBindMountSources|Deploy_(TranslatesBindMountForAllowlistedApplication|RestrictMountsAllowsTranslatedDeploymentBind)|CheckAndPullImages_TranslatesBindMountBeforeUp' -count=1`
- `go test ./... -run '^$'`
- `git diff HEAD^ HEAD --check`

The full Docker-daemon-backed test suite was not rerun during publishing; the focused regression tests and repository-wide Go compilation pass.

Possibly fixes #231 