### PR TITLE
chore: Reduce Docker build caching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
             COMMIT=${{ github.sha }}
             BUILD_DATE=${{ steps.build_date.outputs.value  }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha
           provenance: mode=max
           sbom: true
 


### PR DESCRIPTION
## **Type of change**

- [ ] 🐛 Bug fix
- [ ] 🚀 New feature
- [x] ❓ Other (please specify)

## **Description**

Set Docker build cache mode to default instead of max.

## **Additional context**

The GitHub Actions repo cache usage is higher than max.
