### PR TITLE
fix: Agent and sync bugs

### DIFF
--- a/backend/internal/agent/docker/image_poller.go
+++ b/backend/internal/agent/docker/image_poller.go
@@ -158,8 +158,14 @@ func (p *ImagePoller) runOnce(appID, appName, requestID string) {
 
 	updated, err := checkAndPullImages(ctx, p.client, appID, appName, deleteOld)
 
-	// Only notify the hub when something changed or an error occurred.
-	if !updated && err == nil {
+	// Unsolicited periodic ticks stay silent when nothing changed, to avoid
+	// spamming history/notifications. Explicitly triggered requests (webhook,
+	// manual, GitHub Actions) always report back, even with no change, so the
+	// hub can complete the correlated event and clear the application's
+	// syncing status. Otherwise a duplicate webhook delivery whose pull is a
+	// no-op (the first delivery already pulled the image) leaves its event
+	// stuck "running" and the application stuck "Syncing" until hub restart.
+	if requestID == "" && !updated && err == nil {
 		return
 	}
 

--- a/backend/internal/agent/docker/image_poller_test.go
+++ b/backend/internal/agent/docker/image_poller_test.go
@@ -266,6 +266,40 @@ func TestImagePoller_RunOnce_SilentWhenNothingChanged(t *testing.T) {
 	}
 }
 
+func TestImagePoller_RunOnce_SendsResultOnExplicitRequestEvenWhenNothingChanged(t *testing.T) {
+	origCheck := checkAndPullImages
+	t.Cleanup(func() { checkAndPullImages = origCheck })
+
+	checkAndPullImages = func(_ context.Context, _ *Client, _, _ string, _ bool) (bool, error) {
+		return false, nil // nothing changed, e.g. a duplicate webhook delivery
+	}
+
+	sender := &stubMessageSender{}
+	p := newTestPoller(t, sender)
+	applyOne(p, "app-1", "myapp", PollSettings{Enabled: true, IntervalSeconds: 60})
+	defer p.StopAll()
+
+	p.runOnce("app-1", "myapp", "req-1")
+
+	msgs := sender.received()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	result := msgs[0].GetPullImagesResult()
+	if result == nil {
+		t.Fatal("expected PullImagesResult payload")
+	}
+	if !result.Success {
+		t.Error("expected success=true")
+	}
+	if result.ImagesUpdated {
+		t.Error("expected images_updated=false")
+	}
+	if result.RequestId != "req-1" {
+		t.Errorf("expected request_id %q, got %q", "req-1", result.RequestId)
+	}
+}
+
 func TestImagePoller_RunOnce_SendErrorLogged(t *testing.T) {
 	origCheck := checkAndPullImages
 	t.Cleanup(func() { checkAndPullImages = origCheck })
@@ -315,7 +349,7 @@ func TestImagePoller_TriggerNow(t *testing.T) {
 		return false, nil
 	}
 
-	p := newTestPoller(t, nil)
+	p := newTestPoller(t, noopSender{})
 	p.TriggerNow("app-1", "billing", "req-99")
 
 	select {
@@ -345,7 +379,7 @@ func TestImagePoller_TriggerNow_SerializesSameApplication(t *testing.T) {
 		return false, nil
 	}
 
-	p := newTestPoller(t, nil)
+	p := newTestPoller(t, noopSender{})
 	p.TriggerNow("app-1", "billing", "req-1")
 
 	select {

--- a/backend/internal/agent/websocket.go
+++ b/backend/internal/agent/websocket.go
@@ -252,6 +252,28 @@ func executePullImages(poller pollerHandler, req *messages.PullImagesRequest) {
 	poller.TriggerNow(req.ApplicationId, req.ApplicationName, req.RequestId)
 }
 
+// appExecLocks serializes Deploy/Remove calls per application ID. The hub has
+// no cross-request guarantee that only one deploy is ever in flight for a
+// given application (e.g. a duplicated webhook delivery can dispatch two
+// DeployRequests, or a delete can race a deploy), and executeDeployment /
+// executeDelete each run in their own goroutine. Without this lock, two
+// docker compose invocations for the same project could run concurrently.
+var (
+	appExecMu    sync.Mutex
+	appExecLocks = make(map[string]*sync.Mutex)
+)
+
+func lockForApplication(appID string) *sync.Mutex {
+	appExecMu.Lock()
+	defer appExecMu.Unlock()
+	lock, ok := appExecLocks[appID]
+	if !ok {
+		lock = &sync.Mutex{}
+		appExecLocks[appID] = lock
+	}
+	return lock
+}
+
 func executeDeployment(ctx context.Context, sender outboundSender, deployer deployExecutor, req *messages.DeployRequest) {
 	Log.Info().Str("application_id", req.ApplicationId).Str("request_id", req.RequestId).Msg("starting deployment")
 
@@ -265,6 +287,10 @@ func executeDeployment(ctx context.Context, sender outboundSender, deployer depl
 		sendDeployResult(sender, result)
 		return
 	}
+
+	lock := lockForApplication(req.ApplicationId)
+	lock.Lock()
+	defer lock.Unlock()
 
 	deployCtx, cancel := context.WithTimeout(ctx, deploymentTimeout)
 	defer cancel()
@@ -299,6 +325,10 @@ func executeDelete(ctx context.Context, sender outboundSender, deployer deployEx
 		sendDeleteResult(sender, result)
 		return
 	}
+
+	lock := lockForApplication(req.ApplicationId)
+	lock.Lock()
+	defer lock.Unlock()
 
 	delCtx, cancel := context.WithTimeout(ctx, deploymentTimeout)
 	defer cancel()

--- a/backend/internal/agent/websocket_test.go
+++ b/backend/internal/agent/websocket_test.go
@@ -996,6 +996,56 @@ func TestExecuteDeployment_NilDeployer(t *testing.T) {
 	}
 }
 
+func TestExecuteDeployment_SerializesSameApplication(t *testing.T) {
+	sender := &stubSender{sent: make(chan *messages.ClientMessage, 2)}
+	deployer := &stubDeployer{
+		reqCh: make(chan agentdocker.DeployRequest, 2),
+		block: make(chan struct{}),
+	}
+
+	req := &messages.DeployRequest{
+		ApplicationId:   "app-1",
+		ApplicationName: "billing",
+		ComposeFile:     "services: {}\n",
+	}
+
+	go executeDeployment(context.Background(), sender, deployer, &messages.DeployRequest{
+		RequestId: "req-1", ApplicationId: req.ApplicationId, ApplicationName: req.ApplicationName, ComposeFile: req.ComposeFile,
+	})
+
+	select {
+	case <-deployer.reqCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first deploy to start")
+	}
+
+	go executeDeployment(context.Background(), sender, deployer, &messages.DeployRequest{
+		RequestId: "req-2", ApplicationId: req.ApplicationId, ApplicationName: req.ApplicationName, ComposeFile: req.ComposeFile,
+	})
+
+	select {
+	case <-deployer.reqCh:
+		t.Fatal("second deploy started while the first was still running for the same application")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(deployer.block)
+
+	select {
+	case <-deployer.reqCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second deploy to run after the first completed")
+	}
+
+	for range 2 {
+		select {
+		case <-sender.sent:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for deploy result")
+		}
+	}
+}
+
 type stubReporter struct {
 	health map[string]agentdocker.HealthState
 }

--- a/backend/internal/hub/applications/poller.go
+++ b/backend/internal/hub/applications/poller.go
@@ -108,6 +108,18 @@ func (p *Poller) TriggerSync(repo *models.Repository, origin SyncOrigin) bool {
 	return true
 }
 
+// TryLockRepositorySync attempts to claim the in-flight sync slot for repoID,
+// coordinating with TriggerSync so any trigger source (scheduled poll, manual
+// sync, or a webhook/GitHub Actions handler calling this directly) cannot run
+// a sync for the same repository concurrently. Callers must invoke the
+// returned release func once their own sync attempt returns.
+func (p *Poller) TryLockRepositorySync(repoID string) (release func(), ok bool) {
+	if _, loaded := p.syncing.LoadOrStore(repoID, struct{}{}); loaded {
+		return nil, false
+	}
+	return func() { p.syncing.Delete(repoID) }, true
+}
+
 func (p *Poller) recordManualSyncConflict(repo *models.Repository, origin SyncOrigin) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/backend/internal/hub/applications/poller_test.go
+++ b/backend/internal/hub/applications/poller_test.go
@@ -209,6 +209,67 @@ func TestPoller_TriggerSync_ManualConflictRecordsFailedEvent(t *testing.T) {
 	}
 }
 
+func TestPoller_TryLockRepositorySync_DeduplicatesAcrossCallers(t *testing.T) {
+	nop := zerolog.Nop()
+	p := NewPoller(&nop)
+	t.Cleanup(p.Stop)
+
+	release, ok := p.TryLockRepositorySync("repo-1")
+	if !ok {
+		t.Fatal("expected first lock attempt to succeed")
+	}
+
+	if _, ok := p.TryLockRepositorySync("repo-1"); ok {
+		t.Error("expected second lock attempt for the same repository to be rejected while the first is held")
+	}
+
+	// A different repository must not be blocked by repo-1's lock.
+	otherRelease, ok := p.TryLockRepositorySync("repo-2")
+	if !ok {
+		t.Fatal("expected lock attempt for a different repository to succeed")
+	}
+	otherRelease()
+
+	release()
+
+	if _, ok := p.TryLockRepositorySync("repo-1"); !ok {
+		t.Error("expected lock attempt to succeed again after release")
+	}
+}
+
+func TestPoller_TryLockRepositorySync_CoordinatesWithTriggerSync(t *testing.T) {
+	setupTestDB(t)
+	setupSyncQueue(t)
+
+	repo := seedRepo(t)
+	repo.Provider = testSyncProvider
+	agent := seedAgent(t)
+	seedApp(t, repo.Id, agent.Id, "compose: v1")
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	repositories.Register(testSyncProvider, &mockProvider{
+		onGetLatestCommit: func() {
+			close(started)
+			<-release
+		},
+		latestCommit: repositories.CommitInfo{Hash: "sha", Message: "msg"},
+	})
+
+	nop := zerolog.Nop()
+	p := NewPoller(&nop)
+	t.Cleanup(p.Stop)
+
+	p.TriggerSync(&repo, SyncOrigin{Source: models.ApplicationEventSourceRepositoryPolling})
+	<-started // TriggerSync's sync is in-flight, holding the repo's syncing slot
+
+	if _, ok := p.TryLockRepositorySync(repo.Id); ok {
+		t.Error("expected TryLockRepositorySync to be rejected while TriggerSync holds the same repository's slot")
+	}
+
+	close(release)
+}
+
 func TestPoller_Stop_WaitsForInFlightSyncs(t *testing.T) {
 	setupTestDB(t)
 	setupSyncQueue(t)

--- a/backend/internal/hub/applications/queue.go
+++ b/backend/internal/hub/applications/queue.go
@@ -17,8 +17,12 @@ const defaultWorkerCount = 4
 const maxQueueSize = defaultWorkerCount * 6
 const jobTimeout = 3 * time.Minute
 
-// TODO
-// Prevent multiple concurrent syncs for the same application
+// Concurrent syncs for the same application are guarded at two levels: every
+// sync entry point (poller, manual trigger, webhooks, GitHub Actions) claims
+// the target repository's slot via Poller.TryLockRepositorySync before
+// enqueuing jobs, and the agent serializes Deploy/Remove calls per
+// application, so overlapping triggers cannot run docker compose concurrently
+// against the same project.
 
 type Queue struct {
 	jobs    chan syncJob

--- a/backend/internal/hub/routes/github_actions.go
+++ b/backend/internal/hub/routes/github_actions.go
@@ -239,6 +239,13 @@ func GitHubActionsDeployHandler(c *gin.Context) {
 			return
 		}
 
+		release, ok := tryLockRepositorySync(matchedRepo.Id)
+		if !ok {
+			c.JSON(http.StatusConflict, gin.H{"error": "repository sync already in progress"})
+			return
+		}
+		defer release()
+
 		hubApplications.SyncApplications(ctx, matchedRepo, repoProvider, apps, hubApplications.StaticCommit(claims.Sha, ""), hubApplications.SyncOrigin{Source: models.ApplicationEventSourceGitHubActions}, &hubApplications.Log)
 	}
 

--- a/backend/internal/hub/routes/github_actions_test.go
+++ b/backend/internal/hub/routes/github_actions_test.go
@@ -484,6 +484,37 @@ func TestGitHubActionsDeployHandler_SyncTriggered(t *testing.T) {
 	}
 }
 
+func TestGitHubActionsDeployHandler_SyncRejectedWhenRepositoryAlreadySyncing(t *testing.T) {
+	srv := setupGHActionsTest(t)
+	repo := seedGHActionsRepo(t)
+	seedGHActionsApp(t, repo.Id)
+
+	nop := zerolog.Nop()
+	applications.DefaultPoller = applications.NewPoller(&nop)
+	t.Cleanup(func() { applications.DefaultPoller = nil })
+
+	release, ok := applications.DefaultPoller.TryLockRepositorySync(repo.Id)
+	if !ok {
+		t.Fatal("failed to pre-lock repository sync slot")
+	}
+	defer release()
+
+	token := srv.makeToken(t, githubActionsClaims{
+		Repository: "owner/testrepo",
+		Ref:        "refs/heads/main",
+		RefType:    "branch",
+		EventName:  "push",
+		Sha:        "abc123",
+	})
+
+	c, w := makeGHActionsRequest(token, `{"syncRepo": true}`)
+	GitHubActionsDeployHandler(c)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestGitHubActionsDeployHandler_UnsupportedRefType(t *testing.T) {
 	srv := setupGHActionsTest(t)
 	seedGHActionsRepo(t)

--- a/backend/internal/hub/routes/webhooks.go
+++ b/backend/internal/hub/routes/webhooks.go
@@ -103,12 +103,34 @@ func WebhookHandler(c *gin.Context) {
 		return
 	}
 
+	release, ok := tryLockRepositorySync(repo.Id)
+	if !ok {
+		// A sync for this repository is already in progress, most likely this
+		// exact push redelivered by the provider's webhook retry logic. Skip
+		// silently instead of dispatching a duplicate deploy.
+		c.AbortWithStatus(http.StatusNoContent)
+		return
+	}
+	defer release()
+
 	// TODO: get commit message for push event and pass it to the queue.
 	// Might be simpler to get it via API instead of parsing it from the webhook payload, since the relevant field names differ between providers.
 	// In case we get it from the API we need to add a GetCommitDetails method to the Provider interface which does not pull the latest commit.
 	applications.SyncApplications(c.Request.Context(), &repo, provider, apps, applications.StaticCommit(pushDetails.Commit, ""), applications.SyncOrigin{Source: models.ApplicationEventSourceRepositoryWebhook}, &applications.Log)
 
 	c.AbortWithStatus(http.StatusNoContent)
+}
+
+// tryLockRepositorySync claims the in-flight sync slot for repoID via the
+// default poller so a duplicated webhook delivery cannot dispatch the same
+// sync twice concurrently. Falls back to allowing the sync when the poller
+// isn't initialized (e.g. in tests), since the lock is a best-effort guard,
+// not a correctness requirement.
+func tryLockRepositorySync(repoID string) (release func(), ok bool) {
+	if applications.DefaultPoller == nil {
+		return func() {}, true
+	}
+	return applications.DefaultPoller.TryLockRepositorySync(repoID)
 }
 
 func handleGenericWebhook(c *gin.Context, repo models.Repository) {
@@ -143,6 +165,13 @@ func handleGenericWebhook(c *gin.Context, repo models.Repository) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 		return
 	}
+
+	release, ok := tryLockRepositorySync(repo.Id)
+	if !ok {
+		c.AbortWithStatus(http.StatusNoContent)
+		return
+	}
+	defer release()
 
 	// When the payload omits the commit, resolve the latest commit per branch from
 	// the provider; otherwise deploy the commit the caller supplied.

--- a/backend/internal/hub/routes/webhooks_test.go
+++ b/backend/internal/hub/routes/webhooks_test.go
@@ -223,6 +223,42 @@ func TestWebhookHandler_GitHub_PushEvent_UpdatesDB(t *testing.T) {
 	}
 }
 
+func TestWebhookHandler_GitHub_PushEvent_DeduplicatesConcurrentDelivery(t *testing.T) {
+	setupTestDBWithWebhookRepos(t)
+	nop := zerolog.Nop()
+	applications.DefaultPoller = applications.NewPoller(&nop)
+	t.Cleanup(func() { applications.DefaultPoller = nil })
+
+	const secret = "mysecret"
+	const body = `{"ref":"refs/heads/main","after":"sha-after"}`
+	repo := seedWebhookRepo(t, models.GitHub, secret)
+
+	// Simulate a sync for this repository already in flight, e.g. from the
+	// original delivery of a webhook the provider is now retrying.
+	release, ok := applications.DefaultPoller.TryLockRepositorySync(repo.Id)
+	if !ok {
+		t.Fatal("failed to pre-lock repository sync slot")
+	}
+	defer release()
+
+	c, w := makeWebhookRequest(repo.Id, body)
+	c.Request.Header.Set("X-GitHub-Event", "push")
+	c.Request.Header.Set("X-Hub-Signature-256", githubSig(secret, body))
+	WebhookHandler(c)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var got models.Repository
+	if err := db.DB.First(&got, "id = ?", repo.Id).Error; err != nil {
+		t.Fatalf("failed to reload repo: %v", err)
+	}
+	if got.SyncStatus != models.SyncStatusUnknown {
+		t.Errorf("expected duplicate delivery to be skipped while a sync is in progress, got sync_status %s", got.SyncStatus)
+	}
+}
+
 func TestWebhookHandler_Gitea_InvalidSignature(t *testing.T) {
 	setupTestDBWithWebhookRepos(t)
 	repo := seedWebhookRepo(t, models.Gitea, "mysecret")
@@ -693,6 +729,38 @@ func TestWebhookHandler_Generic_EmptyBody_UpdatesDB(t *testing.T) {
 	}
 	if got.LastSyncedAt == nil {
 		t.Error("expected last_synced_at to be set")
+	}
+}
+
+func TestWebhookHandler_Generic_DeduplicatesConcurrentDelivery(t *testing.T) {
+	setupTestDBWithWebhookRepos(t)
+	nop := zerolog.Nop()
+	applications.DefaultPoller = applications.NewPoller(&nop)
+	t.Cleanup(func() { applications.DefaultPoller = nil })
+
+	const secret = "mysecret"
+	repo := seedWebhookRepo(t, models.GitHub, secret)
+
+	release, ok := applications.DefaultPoller.TryLockRepositorySync(repo.Id)
+	if !ok {
+		t.Fatal("failed to pre-lock repository sync slot")
+	}
+	defer release()
+
+	c, w := makeWebhookRequest(repo.Id, "")
+	c.Request.Header.Set("Authorization", "Bearer "+secret)
+	WebhookHandler(c)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var got models.Repository
+	if err := db.DB.First(&got, "id = ?", repo.Id).Error; err != nil {
+		t.Fatalf("failed to reload repo: %v", err)
+	}
+	if got.SyncStatus != models.SyncStatusUnknown {
+		t.Errorf("expected duplicate delivery to be skipped while a sync is in progress, got sync_status %s", got.SyncStatus)
 	}
 }
 


### PR DESCRIPTION
## **Type of change**

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] ❓ Other (please specify)

## **Description**

Fixes applications getting permanently stuck on "Syncing"/"Unknown" status and history filling up with spurious "Failed" (`hub restarted before the operation result was received`) entries, caused by duplicate webhook deliveries (e.g. GitHub retrying a `package` event for GHCR pushes).

- **Image pull webhook**: the agent silently dropped its response to the hub whenever an image pull found nothing new to pull — even for explicitly triggered requests (webhook/manual/GitHub Actions), not just background polling ticks. When GitHub redelivers a webhook, the second delivery finds the image already pulled by the first and never reports back. The corresponding `application_event` then sits in `running` forever (only cleared on the next hub restart, which is where the "hub restarted..." failures come from), and the application's `sync_status` never gets reset out of `Syncing`.
- **Commit-sync / deployment webhooks**: the same class of duplicate-delivery problem existed here too, plus a more serious gap — there was no locking at all preventing two overlapping deploys for the same application from running concurrently on the agent (`docker compose up` racing against itself for the same project directory).

## Notes for reviewers

- No commit/deploy correctness change is required beyond serialization — the deploy path already always reports a result back to the hub (unlike the image-poll path before this fix), so it doesn't get permanently "stuck"; it was purely a concurrency/race risk.
- The repository-level sync lock is released once the sync call returns (i.e. once jobs are enqueued), not once the deploy actually finishes. In practice this is fine because the agent-side lock added here serializes the actual work — a residual reordering (rather than corruption) risk remains for genuinely back-to-back distinct triggers, which is an acceptable tradeoff over the added complexity of holding the lock across async queue processing.
