### PR TITLE
feat: Image pull debounce

### DIFF
--- a/backend/internal/hub/applications/image_pull.go
+++ b/backend/internal/hub/applications/image_pull.go
@@ -13,7 +13,11 @@ import (
 // TriggerImagePull sends a PullImagesRequest to the agent for the given application
 // and records a correlated image_update history event for the explicit trigger.
 // Returns false if the hub is not initialized, the agent is not connected, or the send buffer is full.
+// Triggers that may arrive in bursts should go through ScheduleImagePull instead.
 func TriggerImagePull(app *models.Application, source models.ApplicationEventSource) bool {
+	// This pull supersedes a debounced one queued for the same application.
+	DefaultImagePullDebouncer.Cancel(app.Id)
+
 	ctx := context.Background()
 	requestID := uuid.NewString()
 	if _, err := applicationevents.Start(ctx, applicationevents.Params{

--- a/backend/internal/hub/applications/image_pull_debounce.go
+++ b/backend/internal/hub/applications/image_pull_debounce.go
@@ -13,16 +13,13 @@ import (
 )
 
 const (
-	// imagePullDebounceWindow is the quiet period a burst of image update
-	// triggers has to settle for before the pull is dispatched. Registries fan a
-	// single push out into several deliveries — GHCR publishes one package event
-	// per manifest of a multi-arch image — so pulling on the first delivery both
-	// floods history and notifications and can race the tag update itself.
+	// imagePullDebounceWindow is the quiet period a burst of image update triggers
+	// has to settle for before the pull is dispatched. One registry push can fan out
+	// into a delivery per manifest of a multi-arch image.
 	imagePullDebounceWindow = 5 * time.Second
 	// imagePullDebounceMaxDelay caps how long a continuous stream of triggers can
 	// postpone the pull.
 	imagePullDebounceMaxDelay = 30 * time.Second
-	imagePullDebounceTimeout  = 10 * time.Second
 )
 
 // DefaultImagePullDebouncer coalesces image update webhook deliveries. It is nil
@@ -37,8 +34,7 @@ type pendingImagePull struct {
 }
 
 // ImagePullDebouncer collapses bursts of image update triggers for the same
-// application into a single pull, so one registry push results in one history
-// entry and one notification instead of one per webhook delivery.
+// application into one pull, so one push yields one history entry and one notification.
 type ImagePullDebouncer struct {
 	mu       sync.Mutex
 	wg       sync.WaitGroup // tracks in-flight dispatches
@@ -69,8 +65,7 @@ func ScheduleImagePull(app *models.Application, source models.ApplicationEventSo
 }
 
 // Schedule queues a pull for appID once no further trigger arrives within the
-// debounce window. Repeated triggers restart that window, but never postpone the
-// pull beyond maxDelay from the first trigger of the burst.
+// debounce window, but never later than maxDelay after the first trigger.
 func (d *ImagePullDebouncer) Schedule(appID string, source models.ApplicationEventSource) {
 	if d == nil {
 		return
@@ -83,12 +78,9 @@ func (d *ImagePullDebouncer) Schedule(appID string, source models.ApplicationEve
 
 	now := time.Now()
 	deadline := now.Add(d.maxDelay)
-	if d.maxDelay <= 0 {
-		deadline = now.Add(d.window)
-	}
 	if pending, ok := d.pending[appID]; ok {
 		if !now.Before(pending.deadline) {
-			// The hard cap elapsed, so the queued pull is already on its way out.
+			// Hard cap elapsed; the queued pull is already on its way out.
 			return
 		}
 		deadline = pending.deadline
@@ -96,15 +88,14 @@ func (d *ImagePullDebouncer) Schedule(appID string, source models.ApplicationEve
 	}
 
 	pending := &pendingImagePull{deadline: deadline, source: source}
-	delay := max(time.Duration(0), min(d.window, deadline.Sub(now)))
+	delay := min(d.window, deadline.Sub(now))
 	pending.timer = time.AfterFunc(delay, func() { d.dispatch(appID, pending) })
 	d.pending[appID] = pending
 
 	d.log.Debug().Str("applicationId", appID).Dur("delay", delay).Msg("image pull scheduled")
 }
 
-// Cancel drops a queued pull for appID. Callers that dispatch a pull through
-// another path use this so the pending burst does not pull a second time.
+// Cancel drops a queued pull for appID, used when a pull is dispatched elsewhere.
 func (d *ImagePullDebouncer) Cancel(appID string) {
 	if d == nil {
 		return
@@ -118,7 +109,6 @@ func (d *ImagePullDebouncer) Cancel(appID string) {
 }
 
 // Stop drops all queued pulls and waits for in-flight dispatches to finish.
-// A pull lost to shutdown is picked up by the next webhook delivery or poll.
 func (d *ImagePullDebouncer) Stop() {
 	if d == nil {
 		return
@@ -133,8 +123,8 @@ func (d *ImagePullDebouncer) Stop() {
 	d.wg.Wait()
 }
 
-// dispatch reloads the application before triggering, since it may have been
-// changed or deleted while the burst was settling.
+// dispatch reloads the application, which may have changed or been deleted while
+// the burst settled, and triggers the pull.
 func (d *ImagePullDebouncer) dispatch(appID string, pending *pendingImagePull) {
 	d.mu.Lock()
 	if d.stopped || d.pending[appID] != pending {
@@ -149,7 +139,7 @@ func (d *ImagePullDebouncer) dispatch(appID string, pending *pendingImagePull) {
 	if db.DB == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), imagePullDebounceTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	app, err := gorm.G[models.Application](db.DB).Where("id = ?", appID).First(ctx)

--- a/backend/internal/hub/applications/image_pull_debounce.go
+++ b/backend/internal/hub/applications/image_pull_debounce.go
@@ -1,0 +1,164 @@
+package applications
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/OrcaCD/orca-cd/internal/hub/db"
+	"github.com/OrcaCD/orca-cd/internal/hub/models"
+	"github.com/rs/zerolog"
+	"gorm.io/gorm"
+)
+
+const (
+	// imagePullDebounceWindow is the quiet period a burst of image update
+	// triggers has to settle for before the pull is dispatched. Registries fan a
+	// single push out into several deliveries — GHCR publishes one package event
+	// per manifest of a multi-arch image — so pulling on the first delivery both
+	// floods history and notifications and can race the tag update itself.
+	imagePullDebounceWindow = 5 * time.Second
+	// imagePullDebounceMaxDelay caps how long a continuous stream of triggers can
+	// postpone the pull.
+	imagePullDebounceMaxDelay = 30 * time.Second
+	imagePullDebounceTimeout  = 10 * time.Second
+)
+
+// DefaultImagePullDebouncer coalesces image update webhook deliveries. It is nil
+// until the hub initializes it, in which case pulls are dispatched immediately.
+var DefaultImagePullDebouncer *ImagePullDebouncer
+
+type pendingImagePull struct {
+	timer *time.Timer
+	// deadline is the hard cap, measured from the first trigger of the burst.
+	deadline time.Time
+	source   models.ApplicationEventSource
+}
+
+// ImagePullDebouncer collapses bursts of image update triggers for the same
+// application into a single pull, so one registry push results in one history
+// entry and one notification instead of one per webhook delivery.
+type ImagePullDebouncer struct {
+	mu       sync.Mutex
+	wg       sync.WaitGroup // tracks in-flight dispatches
+	log      *zerolog.Logger
+	window   time.Duration
+	maxDelay time.Duration
+	pending  map[string]*pendingImagePull
+	stopped  bool
+}
+
+func NewImagePullDebouncer(log *zerolog.Logger) *ImagePullDebouncer {
+	return &ImagePullDebouncer{
+		log:      log,
+		window:   imagePullDebounceWindow,
+		maxDelay: imagePullDebounceMaxDelay,
+		pending:  make(map[string]*pendingImagePull),
+	}
+}
+
+// ScheduleImagePull queues a debounced image pull for app, or dispatches it
+// right away when no debouncer is initialized.
+func ScheduleImagePull(app *models.Application, source models.ApplicationEventSource) {
+	if DefaultImagePullDebouncer == nil {
+		TriggerImagePull(app, source)
+		return
+	}
+	DefaultImagePullDebouncer.Schedule(app.Id, source)
+}
+
+// Schedule queues a pull for appID once no further trigger arrives within the
+// debounce window. Repeated triggers restart that window, but never postpone the
+// pull beyond maxDelay from the first trigger of the burst.
+func (d *ImagePullDebouncer) Schedule(appID string, source models.ApplicationEventSource) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped {
+		return
+	}
+
+	now := time.Now()
+	deadline := now.Add(d.maxDelay)
+	if d.maxDelay <= 0 {
+		deadline = now.Add(d.window)
+	}
+	if pending, ok := d.pending[appID]; ok {
+		if !now.Before(pending.deadline) {
+			// The hard cap elapsed, so the queued pull is already on its way out.
+			return
+		}
+		deadline = pending.deadline
+		pending.timer.Stop()
+	}
+
+	pending := &pendingImagePull{deadline: deadline, source: source}
+	delay := max(time.Duration(0), min(d.window, deadline.Sub(now)))
+	pending.timer = time.AfterFunc(delay, func() { d.dispatch(appID, pending) })
+	d.pending[appID] = pending
+
+	d.log.Debug().Str("applicationId", appID).Dur("delay", delay).Msg("image pull scheduled")
+}
+
+// Cancel drops a queued pull for appID. Callers that dispatch a pull through
+// another path use this so the pending burst does not pull a second time.
+func (d *ImagePullDebouncer) Cancel(appID string) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if pending, ok := d.pending[appID]; ok {
+		pending.timer.Stop()
+		delete(d.pending, appID)
+	}
+}
+
+// Stop drops all queued pulls and waits for in-flight dispatches to finish.
+// A pull lost to shutdown is picked up by the next webhook delivery or poll.
+func (d *ImagePullDebouncer) Stop() {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	d.stopped = true
+	for appID, pending := range d.pending {
+		pending.timer.Stop()
+		delete(d.pending, appID)
+	}
+	d.mu.Unlock()
+	d.wg.Wait()
+}
+
+// dispatch reloads the application before triggering, since it may have been
+// changed or deleted while the burst was settling.
+func (d *ImagePullDebouncer) dispatch(appID string, pending *pendingImagePull) {
+	d.mu.Lock()
+	if d.stopped || d.pending[appID] != pending {
+		d.mu.Unlock()
+		return
+	}
+	delete(d.pending, appID)
+	d.wg.Add(1)
+	d.mu.Unlock()
+	defer d.wg.Done()
+
+	if db.DB == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), imagePullDebounceTimeout)
+	defer cancel()
+
+	app, err := gorm.G[models.Application](db.DB).Where("id = ?", appID).First(ctx)
+	if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			d.log.Error().Err(err).Str("applicationId", appID).
+				Msg("failed to load application for debounced image pull")
+		}
+		return
+	}
+	TriggerImagePull(&app, pending.source)
+}

--- a/backend/internal/hub/applications/image_pull_debounce_test.go
+++ b/backend/internal/hub/applications/image_pull_debounce_test.go
@@ -1,0 +1,212 @@
+package applications
+
+import (
+	"testing"
+	"time"
+
+	"github.com/OrcaCD/orca-cd/internal/hub/db"
+	"github.com/OrcaCD/orca-cd/internal/hub/models"
+	hubws "github.com/OrcaCD/orca-cd/internal/hub/websocket"
+	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"github.com/rs/zerolog"
+	"gorm.io/gorm"
+)
+
+// setupDebouncer installs a debouncer with test timings as the default. It must be
+// called after seedConnectedApp so pending pulls are stopped before the cleanups
+// that tear down the hub and database run.
+func setupDebouncer(t *testing.T, window, maxDelay time.Duration) *ImagePullDebouncer {
+	t.Helper()
+	log := zerolog.Nop()
+	debouncer := NewImagePullDebouncer(&log)
+	debouncer.window = window
+	debouncer.maxDelay = maxDelay
+	DefaultImagePullDebouncer = debouncer
+	t.Cleanup(func() {
+		debouncer.Stop()
+		DefaultImagePullDebouncer = nil
+	})
+	return debouncer
+}
+
+// seedConnectedApp seeds an application whose agent has an open hub connection,
+// so triggered pulls land on the returned client's send channel.
+func seedConnectedApp(t *testing.T) (*models.Application, *hubws.Client) {
+	t.Helper()
+	log := zerolog.Nop()
+	hub := hubws.NewHub(&log)
+	hubws.DefaultHub = hub
+	t.Cleanup(func() { hubws.DefaultHub = nil })
+
+	agent := seedAgent(t)
+	app := seedImagePullApp(t, agent.Id)
+	client, err := hub.Register(agent.Id, nil)
+	if err != nil {
+		t.Fatalf("failed to register agent: %v", err)
+	}
+	return app, client
+}
+
+func awaitPullRequest(t *testing.T, client *hubws.Client) *messages.PullImagesRequest {
+	t.Helper()
+	select {
+	case msg := <-client.Send:
+		req := msg.GetPullImagesRequest()
+		if req == nil {
+			t.Fatalf("expected PullImagesRequest, got %T", msg.Payload)
+		}
+		return req
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for a PullImagesRequest")
+		return nil
+	}
+}
+
+func expectNoPullRequest(t *testing.T, client *hubws.Client, within time.Duration) {
+	t.Helper()
+	select {
+	case msg := <-client.Send:
+		t.Fatalf("expected no further request, got %T", msg.Payload)
+	case <-time.After(within):
+	}
+}
+
+func countImageUpdateEvents(t *testing.T, appID string) int {
+	t.Helper()
+	events, err := gorm.G[models.ApplicationEvent](db.DB).
+		Where("application_id = ? AND type = ?", appID, models.ApplicationEventImageUpdate).
+		Find(t.Context())
+	if err != nil {
+		t.Fatalf("failed to load events: %v", err)
+	}
+	return len(events)
+}
+
+func TestScheduleImagePull_CoalescesBurstIntoSinglePull(t *testing.T) {
+	setupTestDB(t)
+	app, client := seedConnectedApp(t)
+	setupDebouncer(t, 40*time.Millisecond, time.Second)
+
+	// A single registry push arrives as several webhook deliveries.
+	for range 3 {
+		ScheduleImagePull(app, models.ApplicationEventSourceImageWebhook)
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	req := awaitPullRequest(t, client)
+	if req.ApplicationId != app.Id {
+		t.Errorf("application_id: got %q, want %q", req.ApplicationId, app.Id)
+	}
+	expectNoPullRequest(t, client, 200*time.Millisecond)
+
+	if got := countImageUpdateEvents(t, app.Id); got != 1 {
+		t.Errorf("expected 1 image_update event for the burst, got %d", got)
+	}
+}
+
+func TestScheduleImagePull_SeparateBurstsPullAgain(t *testing.T) {
+	setupTestDB(t)
+	app, client := seedConnectedApp(t)
+	setupDebouncer(t, 30*time.Millisecond, time.Second)
+
+	ScheduleImagePull(app, models.ApplicationEventSourceImageWebhook)
+	awaitPullRequest(t, client)
+
+	ScheduleImagePull(app, models.ApplicationEventSourceImageWebhook)
+	awaitPullRequest(t, client)
+
+	if got := countImageUpdateEvents(t, app.Id); got != 2 {
+		t.Errorf("expected 2 image_update events for 2 bursts, got %d", got)
+	}
+}
+
+func TestScheduleImagePull_MaxDelayCapsPostponement(t *testing.T) {
+	setupTestDB(t)
+	app, client := seedConnectedApp(t)
+	// A quiet window this long never settles while triggers keep arriving; only
+	// the max delay can release the pull.
+	setupDebouncer(t, 5*time.Second, 40*time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 20 {
+			ScheduleImagePull(app, models.ApplicationEventSourceImageWebhook)
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	awaitPullRequest(t, client)
+	<-done
+}
+
+func TestScheduleImagePull_ImmediateTriggerSupersedesQueuedPull(t *testing.T) {
+	setupTestDB(t)
+	app, client := seedConnectedApp(t)
+	debouncer := setupDebouncer(t, time.Hour, time.Hour)
+
+	ScheduleImagePull(app, models.ApplicationEventSourceImageWebhook)
+	if !TriggerImagePull(app, models.ApplicationEventSourceGitHubActions) {
+		t.Fatal("expected TriggerImagePull to return true for connected agent")
+	}
+
+	req := awaitPullRequest(t, client)
+	if req.ApplicationId != app.Id {
+		t.Errorf("application_id: got %q, want %q", req.ApplicationId, app.Id)
+	}
+
+	debouncer.mu.Lock()
+	pending := len(debouncer.pending)
+	debouncer.mu.Unlock()
+	if pending != 0 {
+		t.Errorf("expected the queued pull to be dropped, got %d pending", pending)
+	}
+}
+
+func TestImagePullDebouncer_Stop_DropsQueuedPull(t *testing.T) {
+	setupTestDB(t)
+	app, client := seedConnectedApp(t)
+	debouncer := setupDebouncer(t, 30*time.Millisecond, time.Second)
+
+	ScheduleImagePull(app, models.ApplicationEventSourceImageWebhook)
+	debouncer.Stop()
+
+	expectNoPullRequest(t, client, 200*time.Millisecond)
+	if got := countImageUpdateEvents(t, app.Id); got != 0 {
+		t.Errorf("expected no image_update event after Stop, got %d", got)
+	}
+
+	// Triggers after Stop are ignored as well.
+	ScheduleImagePull(app, models.ApplicationEventSourceImageWebhook)
+	expectNoPullRequest(t, client, 100*time.Millisecond)
+}
+
+func TestImagePullDebouncer_DeletedApplication_NoPull(t *testing.T) {
+	setupTestDB(t)
+	app, client := seedConnectedApp(t)
+	setupDebouncer(t, 30*time.Millisecond, time.Second)
+
+	ScheduleImagePull(app, models.ApplicationEventSourceImageWebhook)
+	if _, err := gorm.G[models.Application](db.DB).Where("id = ?", app.Id).Delete(t.Context()); err != nil {
+		t.Fatalf("failed to delete application: %v", err)
+	}
+
+	expectNoPullRequest(t, client, 300*time.Millisecond)
+}
+
+func TestScheduleImagePull_NoDebouncer_TriggersImmediately(t *testing.T) {
+	setupTestDB(t)
+	app, client := seedConnectedApp(t)
+	DefaultImagePullDebouncer = nil
+
+	ScheduleImagePull(app, models.ApplicationEventSourceImageWebhook)
+
+	select {
+	case msg := <-client.Send:
+		if msg.GetPullImagesRequest() == nil {
+			t.Errorf("expected PullImagesRequest, got %T", msg.Payload)
+		}
+	default:
+		t.Error("expected an immediate PullImagesRequest without a debouncer")
+	}
+}

--- a/backend/internal/hub/routes/image_pull_webhook.go
+++ b/backend/internal/hub/routes/image_pull_webhook.go
@@ -76,7 +76,7 @@ func ImagePullWebhookHandler(c *gin.Context) {
 			c.AbortWithStatus(http.StatusNoContent)
 			return
 		}
-		applications.TriggerImagePull(&app, models.ApplicationEventSourceImageWebhook)
+		applications.ScheduleImagePull(&app, models.ApplicationEventSourceImageWebhook)
 		c.AbortWithStatus(http.StatusNoContent)
 		return
 	}
@@ -98,7 +98,7 @@ func ImagePullWebhookHandler(c *gin.Context) {
 
 	// Docker Hub payloads carry a push_data field; all Docker Hub webhooks are push events.
 	if isDockerHubPayload(body) {
-		applications.TriggerImagePull(&app, models.ApplicationEventSourceImageWebhook)
+		applications.ScheduleImagePull(&app, models.ApplicationEventSourceImageWebhook)
 		c.AbortWithStatus(http.StatusNoContent)
 		return
 	}
@@ -109,7 +109,7 @@ func ImagePullWebhookHandler(c *gin.Context) {
 		return
 	}
 
-	applications.TriggerImagePull(&app, models.ApplicationEventSourceImageWebhook)
+	applications.ScheduleImagePull(&app, models.ApplicationEventSourceImageWebhook)
 	c.AbortWithStatus(http.StatusNoContent)
 }
 

--- a/backend/internal/hub/routes/image_pull_webhook_test.go
+++ b/backend/internal/hub/routes/image_pull_webhook_test.go
@@ -428,6 +428,60 @@ func TestImagePullWebhookHandler_GitHubPackage_Updated_TriggersPull(t *testing.T
 	}
 }
 
+// A registry push fans out into several deliveries (GHCR sends one package event
+// per manifest). They must collapse into a single pull instead of one deploy
+// attempt, history entry and notification each.
+func TestImagePullWebhookHandler_GitHubPackage_BurstIsDebounced(t *testing.T) {
+	setupTestDBForImagePullWebhook(t)
+	hub := setupHubForTest(t)
+
+	const secret = "mysecret"
+	const agentID = "agent-pkg-burst"
+	const body = `{"action":"published","package":{"package_type":"CONTAINER"}}`
+
+	app := seedAppWithWebhookSecret(t, secret)
+	if err := db.DB.Model(&models.Application{}).Where("id = ?", app.Id).Update("agent_id", agentID).Error; err != nil {
+		t.Fatalf("failed to update agent_id: %v", err)
+	}
+
+	client, err := hub.Register(agentID, nil)
+	if err != nil {
+		t.Fatalf("failed to register agent: %v", err)
+	}
+
+	nop := zerolog.Nop()
+	debouncer := applications.NewImagePullDebouncer(&nop)
+	applications.DefaultImagePullDebouncer = debouncer
+	t.Cleanup(func() {
+		debouncer.Stop()
+		applications.DefaultImagePullDebouncer = nil
+	})
+
+	for range 3 {
+		c, w := makeGitHubPackageRequest(app.Id, body, imagePullHMAC(secret, body))
+		ImagePullWebhookHandler(c)
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+
+	// Nothing is dispatched while the debounce window is still open.
+	select {
+	case msg := <-client.Send:
+		t.Fatalf("expected the burst to be debounced, got %T", msg.Payload)
+	default:
+	}
+
+	events, err := gorm.G[models.ApplicationEvent](db.DB).
+		Where("application_id = ?", app.Id).Find(t.Context())
+	if err != nil {
+		t.Fatalf("failed to load events: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected no history events while the burst settles, got %d", len(events))
+	}
+}
+
 func TestImagePullWebhookHandler_GitHubPackage_InvalidSignature_Returns401(t *testing.T) {
 	setupTestDBForImagePullWebhook(t)
 

--- a/backend/internal/hub/server.go
+++ b/backend/internal/hub/server.go
@@ -139,6 +139,9 @@ func Run(cfg Config) error {
 	applications.DefaultPoller.Start()
 	defer applications.DefaultPoller.Stop()
 
+	applications.DefaultImagePullDebouncer = applications.NewImagePullDebouncer(&Log)
+	defer applications.DefaultImagePullDebouncer.Stop()
+
 	if !cfg.Demo {
 		defer db.StartVacuumScheduler()()
 	}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -526,7 +526,7 @@
 	"imagePollDeleteOldImagesDescription": "Remove replaced image versions after a successful update",
 	"validationImagePollIntervalMin": "Polling interval must be at least 60 seconds",
 	"imagePullWebhookSectionTitle": "Image Pull Webhook",
-	"imagePullWebhookDescription": "Trigger an image pull when a container image is pushed to your registry. Supports Docker Hub, Harbor, GitHub Container Registry, and any generic registry. For Docker Hub, append ?token=<secret> to the webhook URL instead of using an Authorization header.",
+	"imagePullWebhookDescription": "Trigger an image pull when a container image is pushed to your registry. Supports Docker Hub, Harbor, GitHub Container Registry, and any generic registry. For Docker Hub, append ?token=<secret> to the webhook URL instead of using an Authorization header. Deliveries arriving within a few seconds of each other are combined into a single pull, so one push that fires several webhooks results in one deployment.",
 	"generateWebhook": "Generate Webhook",
 	"regenerateWebhook": "Regenerate",
 	"revokeWebhook": "Revoke",


### PR DESCRIPTION
## **Type of change**

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] ❓ Other (please specify)

## **Description**

A single registry push often arrives as several webhook deliveries. GHCR publishes one
`package` event per manifest of a multi-arch image, so pushing one tag fired three image
update webhooks — three pull attempts, three history entries, and three notifications for
what the user experienced as one deployment.

Image update webhooks now go through a per-application debouncer on the hub. A delivery
queues the pull instead of dispatching it; further deliveries for the same application
restart a 5s quiet window, capped at 30s from the first delivery of the burst so a
continuous stream cannot postpone the pull indefinitely. Once the burst settles, exactly
one `PullImagesRequest` goes out, which means one history entry and one notification.

- `ImagePullDebouncer` (`internal/hub/applications/image_pull_debounce.go`) holds the
  pending pull per application, reloads the application before dispatching (it may have
  been changed or deleted while the burst settled), and drops queued pulls on hub shutdown.
- All three webhook flavours in `ImagePullWebhookHandler` (GitHub, Docker Hub,
  Harbor/generic) call `ScheduleImagePull`; the handler still responds `204` immediately.
- `TriggerImagePull` cancels a queued pull for the same application, so an immediate
  trigger is not followed by a redundant debounced one a few seconds later.
- The GitHub Actions endpoint keeps triggering immediately — it reports back whether the
  agent accepted the pull, so it cannot be deferred.
- The webhook description in the UI mentions the coalescing, since deployments now start a
  few seconds after the push.

## **Additional context**

Why the burst is coalesced rather than deduplicated on the first delivery: `buildx` pushes
the arch-specific child manifests before the tagged manifest list. Pulling on the first
delivery can therefore see the old tag ("No change") and would skip the delivery that
actually carries the update. Waiting for the burst to settle means the single pull sees the
final image.

The debounce window and cap are constants, matching the agent's `healthWatcher` debounce.
If a registry spreads its deliveries wider than the 30s cap, the extra pull reports "No
change" as before, and image polling still catches anything missed.
