### PR TITLE
feat: Enhance handshake security (Breaking Change)

### DIFF
--- a/backend/internal/agent/agent.go
+++ b/backend/internal/agent/agent.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/OrcaCD/orca-cd/internal/agent/docker"
 	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"github.com/OrcaCD/orca-cd/internal/shared/agenttoken"
 	"github.com/OrcaCD/orca-cd/internal/shared/logger"
 	"github.com/OrcaCD/orca-cd/internal/version"
 	"github.com/golang-jwt/jwt/v5"
@@ -37,6 +38,7 @@ type Config struct {
 	AuthToken                     string
 	AgentID                       string
 	HubPublicKey                  ed25519.PublicKey
+	SigningPrivateKey             ed25519.PrivateKey
 	HealthPort                    string
 	DeploymentsDir                string
 	AllowedPrivilegedApps         map[string]struct{}
@@ -61,7 +63,12 @@ func DefaultConfig() (Config, error) {
 		return Config{}, &FatalConfigError{"AUTH_TOKEN is not set — set the AUTH_TOKEN environment variable and recreate the container"}
 	}
 
-	agentID, hubPublicKey, err := parseTokenClaims(authToken)
+	jwtToken, signingPrivateKey, err := agenttoken.Decode(authToken)
+	if err != nil {
+		return Config{}, &FatalConfigError{fmt.Sprintf("AUTH_TOKEN: %s", err)}
+	}
+
+	agentID, hubPublicKey, err := parseTokenClaims(jwtToken)
 	if err != nil {
 		return Config{}, fmt.Errorf("AUTH_TOKEN: %w", err)
 	}
@@ -96,9 +103,10 @@ func DefaultConfig() (Config, error) {
 		LogLevel:                      logLevel,
 		LogJSON:                       logJSON,
 		HubUrl:                        hubUrl,
-		AuthToken:                     authToken,
+		AuthToken:                     jwtToken,
 		AgentID:                       agentID,
 		HubPublicKey:                  hubPublicKey,
+		SigningPrivateKey:             signingPrivateKey,
 		HealthPort:                    healthPort,
 		DeploymentsDir:                deploymentsDir,
 		AllowedPrivilegedApps:         allowedPrivilegedApps,

--- a/backend/internal/agent/agent_config_test.go
+++ b/backend/internal/agent/agent_config_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"github.com/OrcaCD/orca-cd/internal/shared/agenttoken"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
@@ -39,8 +40,25 @@ func makeTestToken(t *testing.T, agentID string) (tokenStr string, hubPubKey ed2
 	return str, pub
 }
 
+// makeTestAuthToken builds a full compound AUTH_TOKEN (JWT + appended signing
+// seed) as issued by the hub, for tests exercising DefaultConfig end-to-end.
+func makeTestAuthToken(t *testing.T) (authToken string, hubPubKey ed25519.PublicKey, signingPriv ed25519.PrivateKey) {
+	t.Helper()
+	jwtStr, hubPub := makeTestToken(t, "test-agent-id")
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 signing key: %v", err)
+	}
+	token, err := agenttoken.Encode(jwtStr, priv.Seed())
+	if err != nil {
+		t.Fatalf("agenttoken.Encode: %v", err)
+	}
+	return token, hubPub, priv
+}
+
 func TestDefaultConfig_Valid(t *testing.T) {
-	token, _ := makeTestToken(t, "test-agent-id")
+	token, _, signingPriv := makeTestAuthToken(t)
+	jwtToken, _, _ := agenttoken.Decode(token)
 	t.Setenv("HUB_URL", "https://hub.example.com")
 	t.Setenv("AUTH_TOKEN", token)
 	t.Setenv("LOG_LEVEL", "debug")
@@ -61,8 +79,8 @@ func TestDefaultConfig_Valid(t *testing.T) {
 	if cfg.HubUrl != "wss://hub.example.com/api/v1/ws" {
 		t.Errorf("HubUrl = %q, want %q", cfg.HubUrl, "wss://hub.example.com/api/v1/ws")
 	}
-	if cfg.AuthToken != token {
-		t.Errorf("AuthToken not set correctly")
+	if cfg.AuthToken != jwtToken {
+		t.Errorf("AuthToken = %q, want the bare JWT %q", cfg.AuthToken, jwtToken)
 	}
 	if cfg.AgentID != "test-agent-id" {
 		t.Errorf("AgentID = %q, want %q", cfg.AgentID, "test-agent-id")
@@ -70,13 +88,16 @@ func TestDefaultConfig_Valid(t *testing.T) {
 	if len(cfg.HubPublicKey) != ed25519.PublicKeySize {
 		t.Errorf("HubPublicKey length = %d, want %d", len(cfg.HubPublicKey), ed25519.PublicKeySize)
 	}
+	if !cfg.SigningPrivateKey.Equal(signingPriv) {
+		t.Error("SigningPrivateKey does not match the key encoded into the token")
+	}
 	if cfg.DeploymentsDir != "/test/deployments" {
 		t.Errorf("DeploymentsDir = %q, want %q", cfg.DeploymentsDir, "/test/deployments")
 	}
 }
 
 func TestDefaultConfig_Defaults(t *testing.T) {
-	token, _ := makeTestToken(t, "test-agent-id")
+	token, _, _ := makeTestAuthToken(t)
 	t.Setenv("HUB_URL", "https://hub.example.com")
 	t.Setenv("AUTH_TOKEN", token)
 	t.Setenv("LOG_LEVEL", "")
@@ -114,7 +135,7 @@ func TestDefaultConfig_LogLevels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			token, _ := makeTestToken(t, "test-agent-id")
+			token, _, _ := makeTestAuthToken(t)
 			t.Setenv("HUB_URL", "https://hub.example.com")
 			t.Setenv("AUTH_TOKEN", token)
 			t.Setenv("LOG_LEVEL", tt.input)
@@ -144,7 +165,7 @@ func TestDefaultConfig_LogJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			token, _ := makeTestToken(t, "test-agent-id")
+			token, _, _ := makeTestAuthToken(t)
 			t.Setenv("HUB_URL", "https://hub.example.com")
 			t.Setenv("AUTH_TOKEN", token)
 			t.Setenv("LOG_JSON", tt.input)
@@ -174,7 +195,7 @@ func TestDefaultConfig_RestrictBindMountsToDeployDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			token, _ := makeTestToken(t, "test-agent-id")
+			token, _, _ := makeTestAuthToken(t)
 			t.Setenv("HUB_URL", "https://hub.example.com")
 			t.Setenv("AUTH_TOKEN", token)
 			t.Setenv("RESTRICT_VOLUMES_TO_DEPLOYMENTS_DIR", tt.input)
@@ -332,8 +353,24 @@ func TestSenderRef_SendMessageDelegates(t *testing.T) {
 	}
 }
 
+func TestDefaultConfig_MissingSigningKeySegment(t *testing.T) {
+	// A bare 3-segment JWT (pre-compound-token format) must be rejected.
+	bareJWT, _ := makeTestToken(t, "test-agent-id")
+	t.Setenv("HUB_URL", "https://hub.example.com")
+	t.Setenv("AUTH_TOKEN", bareJWT)
+
+	_, err := DefaultConfig()
+	if err == nil {
+		t.Fatal("expected error for token missing signing-key segment")
+	}
+	var fatalErr *FatalConfigError
+	if !errors.As(err, &fatalErr) {
+		t.Errorf("expected *FatalConfigError, got %T: %v", err, err)
+	}
+}
+
 func TestDefaultConfig_Errors(t *testing.T) {
-	validToken, _ := makeTestToken(t, "test-agent-id")
+	validToken, _, _ := makeTestAuthToken(t)
 	tests := []struct {
 		name      string
 		hubURL    string

--- a/backend/internal/agent/websocket.go
+++ b/backend/internal/agent/websocket.go
@@ -58,7 +58,7 @@ func newMessageSender(conn *websocket.Conn, session *wscrypto.Session) *messageS
 	}
 }
 
-func performHandshake(conn *websocket.Conn, agentID string, hubPubKey ed25519.PublicKey) (*wscrypto.Session, error) {
+func performHandshake(conn *websocket.Conn, agentID string, hubPubKey ed25519.PublicKey, signingPrivKey ed25519.PrivateKey) (*wscrypto.Session, error) {
 	if err := conn.SetReadDeadline(time.Now().Add(handshakeTimeout)); err != nil {
 		return nil, fmt.Errorf("set read deadline: %w", err)
 	}
@@ -91,11 +91,14 @@ func performHandshake(conn *websocket.Conn, agentID string, hubPubKey ed25519.Pu
 		return nil, fmt.Errorf("agent handshake: %w", err)
 	}
 
+	agentSignature := ed25519.Sign(signingPrivKey, wscrypto.AgentResponseSignaturePayload(mlkemCiphertext, agentX25519Pub, agentID))
+
 	resp := &messages.ClientMessage{
 		Payload: &messages.ClientMessage_KeyExchangeResponse{
 			KeyExchangeResponse: &messages.KeyExchangeResponse{
 				MlkemCiphertext:      mlkemCiphertext,
 				AgentX25519PublicKey: agentX25519Pub,
+				AgentSignature:       agentSignature,
 			},
 		},
 	}
@@ -380,7 +383,7 @@ func connectAndHandshake(ctx context.Context, cfg Config, tracker *connTracker) 
 	if err != nil || tracker.setAndCancelled(ctx, conn) {
 		return nil, nil, nil
 	}
-	session, err := performHandshake(conn, cfg.AgentID, cfg.HubPublicKey)
+	session, err := performHandshake(conn, cfg.AgentID, cfg.HubPublicKey, cfg.SigningPrivateKey)
 	if err != nil {
 		Log.Error().Err(err).Msg("handshake failed")
 		_ = conn.Close()

--- a/backend/internal/agent/websocket_test.go
+++ b/backend/internal/agent/websocket_test.go
@@ -373,6 +373,10 @@ func TestPerformHandshake_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
+	agentSigningPub, agentSigningPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
 
 	const agentID = "agent-1"
 	sig := signHandshakeInit(t, hubPriv, hubKeys.MLKEMEncapKey, hubKeys.X25519PublicKey, agentID)
@@ -406,11 +410,16 @@ func TestPerformHandshake_Success(t *testing.T) {
 		resp := clientMsg.GetKeyExchangeResponse()
 		if resp == nil {
 			t.Error("expected KeyExchangeResponse")
+			return
+		}
+		payload := wscrypto.AgentResponseSignaturePayload(resp.MlkemCiphertext, resp.AgentX25519PublicKey, agentID)
+		if !ed25519.Verify(agentSigningPub, payload, resp.AgentSignature) {
+			t.Error("KeyExchangeResponse signature does not verify against agent's public key")
 		}
 	})
 
 	conn := dialServer(t, srv)
-	session, err := performHandshake(conn, agentID, hubPub)
+	session, err := performHandshake(conn, agentID, hubPub, agentSigningPriv)
 	if err != nil {
 		t.Fatalf("performHandshake: %v", err)
 	}
@@ -425,6 +434,11 @@ func TestPerformHandshake_InvalidSignature(t *testing.T) {
 		t.Fatalf("GenerateHubKeys: %v", err)
 	}
 	hubPub, hubPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	_, agentSigningPriv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
@@ -448,14 +462,14 @@ func TestPerformHandshake_InvalidSignature(t *testing.T) {
 	})
 
 	conn := dialServer(t, srv)
-	_, err = performHandshake(conn, "agent-1", hubPub)
+	_, err = performHandshake(conn, "agent-1", hubPub, agentSigningPriv)
 	if err == nil {
 		t.Fatal("expected error for invalid hub signature")
 	}
 }
 
 func TestPerformHandshake_WrongMessageType(t *testing.T) {
-	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
@@ -473,14 +487,14 @@ func TestPerformHandshake_WrongMessageType(t *testing.T) {
 	})
 
 	conn := dialServer(t, srv)
-	_, err = performHandshake(conn, "agent-1", pub)
+	_, err = performHandshake(conn, "agent-1", pub, priv)
 	if err == nil {
 		t.Fatal("expected error when server sends wrong message type")
 	}
 }
 
 func TestPerformHandshake_InvalidProtoData(t *testing.T) {
-	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
@@ -494,7 +508,7 @@ func TestPerformHandshake_InvalidProtoData(t *testing.T) {
 	})
 
 	conn := dialServer(t, srv)
-	_, err = performHandshake(conn, "agent-1", pub)
+	_, err = performHandshake(conn, "agent-1", pub, priv)
 	if err == nil {
 		t.Fatal("expected error for invalid protobuf data")
 	}

--- a/backend/internal/hub/auth/jwt.go
+++ b/backend/internal/hub/auth/jwt.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/ed25519"
 	"crypto/hkdf"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/OrcaCD/orca-cd/internal/hub/crypto"
 	"github.com/OrcaCD/orca-cd/internal/hub/models"
+	"github.com/OrcaCD/orca-cd/internal/shared/agenttoken"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -132,6 +134,12 @@ func GenerateAgentToken(agent *models.Agent) (string, error) {
 	}
 	agent.KeyId = crypto.EncryptedString(keyId)
 
+	signingPub, signingPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate agent signing key: %w", err)
+	}
+	agent.SigningPublicKey = base64.StdEncoding.EncodeToString(signingPub)
+
 	now := time.Now()
 
 	claims := AgentClaims{
@@ -147,7 +155,12 @@ func GenerateAgentToken(agent *models.Agent) (string, error) {
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
-	return token.SignedString(privateKey)
+	signedToken, err := token.SignedString(privateKey)
+	if err != nil {
+		return "", err
+	}
+
+	return agenttoken.Encode(signedToken, signingPriv.Seed())
 }
 
 func ValidateAgentToken(tokenString string) (*AgentClaims, error) {

--- a/backend/internal/hub/auth/jwt_test.go
+++ b/backend/internal/hub/auth/jwt_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/OrcaCD/orca-cd/internal/hub/crypto"
 	"github.com/OrcaCD/orca-cd/internal/hub/models"
+	"github.com/OrcaCD/orca-cd/internal/shared/agenttoken"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -239,11 +240,11 @@ func TestGenerateAndValidateAgentToken(t *testing.T) {
 
 	agent := &models.Agent{Base: models.Base{Id: "agent-456"}, KeyId: crypto.EncryptedString("key-abc")}
 	initialKeyId := agent.KeyId.String()
-	tokenStr, err := GenerateAgentToken(agent)
+	compoundToken, err := GenerateAgentToken(agent)
 	if err != nil {
 		t.Fatalf("GenerateAgentToken() error: %v", err)
 	}
-	if tokenStr == "" {
+	if compoundToken == "" {
 		t.Fatal("GenerateAgentToken() returned empty token")
 	}
 	if agent.KeyId.String() == "" {
@@ -251,6 +252,21 @@ func TestGenerateAndValidateAgentToken(t *testing.T) {
 	}
 	if agent.KeyId.String() == initialKeyId {
 		t.Fatal("GenerateAgentToken() expected to rotate KeyId")
+	}
+	if agent.SigningPublicKey == "" {
+		t.Fatal("GenerateAgentToken() expected to set SigningPublicKey")
+	}
+
+	tokenStr, signingKey, err := agenttoken.Decode(compoundToken)
+	if err != nil {
+		t.Fatalf("agenttoken.Decode() error: %v", err)
+	}
+	signingPubBytes, err := base64.StdEncoding.DecodeString(agent.SigningPublicKey)
+	if err != nil {
+		t.Fatalf("decode SigningPublicKey: %v", err)
+	}
+	if !signingKey.Public().(ed25519.PublicKey).Equal(ed25519.PublicKey(signingPubBytes)) {
+		t.Error("signing key encoded into the token does not match agent.SigningPublicKey")
 	}
 
 	claims, err := ValidateAgentToken(tokenStr)
@@ -288,9 +304,13 @@ func TestSignHandshake(t *testing.T) {
 	initAll(t)
 
 	agent := &models.Agent{Base: models.Base{Id: "agent-sign-test"}}
-	tokenStr, err := GenerateAgentToken(agent)
+	compoundToken, err := GenerateAgentToken(agent)
 	if err != nil {
 		t.Fatalf("GenerateAgentToken() error: %v", err)
+	}
+	tokenStr, _, err := agenttoken.Decode(compoundToken)
+	if err != nil {
+		t.Fatalf("agenttoken.Decode() error: %v", err)
 	}
 	claims, err := ValidateAgentToken(tokenStr)
 	if err != nil {
@@ -316,17 +336,21 @@ func TestGenerateAndValidateAgentToken_SetsKeyIdWhenMissing(t *testing.T) {
 	initAll(t)
 
 	agent := &models.Agent{Base: models.Base{Id: "agent-789"}}
-	tokenStr, err := GenerateAgentToken(agent)
+	compoundToken, err := GenerateAgentToken(agent)
 	if err != nil {
 		t.Fatalf("GenerateAgentToken() error: %v", err)
 	}
-	if tokenStr == "" {
+	if compoundToken == "" {
 		t.Fatal("GenerateAgentToken() returned empty token")
 	}
 	if agent.KeyId.String() == "" {
 		t.Fatal("GenerateAgentToken() expected to set KeyId when missing")
 	}
 
+	tokenStr, _, err := agenttoken.Decode(compoundToken)
+	if err != nil {
+		t.Fatalf("agenttoken.Decode() error: %v", err)
+	}
 	claims, err := ValidateAgentToken(tokenStr)
 	if err != nil {
 		t.Fatalf("ValidateAgentToken() error: %v", err)

--- a/backend/internal/hub/db/migrations/000026_add_agent_signing_public_key.down.sql
+++ b/backend/internal/hub/db/migrations/000026_add_agent_signing_public_key.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agents DROP COLUMN signing_public_key;

--- a/backend/internal/hub/db/migrations/000026_add_agent_signing_public_key.up.sql
+++ b/backend/internal/hub/db/migrations/000026_add_agent_signing_public_key.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agents ADD COLUMN signing_public_key TEXT NOT NULL DEFAULT '';

--- a/backend/internal/hub/models/agents.go
+++ b/backend/internal/hub/models/agents.go
@@ -16,10 +16,11 @@ const (
 
 type Agent struct {
 	Base
-	Name         crypto.EncryptedString `gorm:"type:text;not null"`
-	Icon         string                 `gorm:"type:text;not null;default:server"`
-	KeyId        crypto.EncryptedString `gorm:"type:text;not null;"`
-	Status       AgentStatus            `gorm:"type:integer;default:0"`
-	LastSeen     *time.Time
-	Applications []Application `gorm:"foreignKey:AgentId;"`
+	Name             crypto.EncryptedString `gorm:"type:text;not null"`
+	Icon             string                 `gorm:"type:text;not null;default:server"`
+	KeyId            crypto.EncryptedString `gorm:"type:text;not null;"`
+	SigningPublicKey string                 `gorm:"type:text;not null;default:''"`
+	Status           AgentStatus            `gorm:"type:integer;default:0"`
+	LastSeen         *time.Time
+	Applications     []Application `gorm:"foreignKey:AgentId;"`
 }

--- a/backend/internal/hub/routes/agents.go
+++ b/backend/internal/hub/routes/agents.go
@@ -200,7 +200,10 @@ func CreateAgentHandler(c *gin.Context) {
 
 		authToken = token
 
-		if _, err := gorm.G[models.Agent](tx).Where("id = ?", agent.Id).Update(ctx, "key_id", agent.KeyId); err != nil {
+		if _, err := gorm.G[models.Agent](tx).Where("id = ?", agent.Id).Updates(ctx, models.Agent{
+			KeyId:            agent.KeyId,
+			SigningPublicKey: agent.SigningPublicKey,
+		}); err != nil {
 			return err
 		}
 
@@ -299,7 +302,10 @@ func RotateAgentTokenHandler(c *gin.Context) {
 		return
 	}
 
-	if _, err := gorm.G[models.Agent](db.DB).Where("id = ?", agent.Id).Update(ctx, "key_id", agent.KeyId); err != nil {
+	if _, err := gorm.G[models.Agent](db.DB).Where("id = ?", agent.Id).Updates(ctx, models.Agent{
+		KeyId:            agent.KeyId,
+		SigningPublicKey: agent.SigningPublicKey,
+	}); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 		return
 	}

--- a/backend/internal/hub/routes/agents_test.go
+++ b/backend/internal/hub/routes/agents_test.go
@@ -2,6 +2,8 @@ package routes
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -14,6 +16,7 @@ import (
 	"github.com/OrcaCD/orca-cd/internal/hub/db"
 	"github.com/OrcaCD/orca-cd/internal/hub/models"
 	"github.com/OrcaCD/orca-cd/internal/hub/websocket"
+	"github.com/OrcaCD/orca-cd/internal/shared/agenttoken"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
 	"gorm.io/gorm"
@@ -279,7 +282,11 @@ func TestCreateAgentHandler_Success(t *testing.T) {
 		t.Fatal("expected authToken to be set")
 	}
 
-	claims, err := auth.ValidateAgentToken(body.AuthToken)
+	jwtToken, signingPriv, err := agenttoken.Decode(body.AuthToken)
+	if err != nil {
+		t.Fatalf("failed to decode compound auth token: %v", err)
+	}
+	claims, err := auth.ValidateAgentToken(jwtToken)
 	if err != nil {
 		t.Fatalf("failed to validate returned auth token: %v", err)
 	}
@@ -302,6 +309,16 @@ func TestCreateAgentHandler_Success(t *testing.T) {
 	}
 	if agent.Icon != "satellite-dish" {
 		t.Fatalf("expected stored icon %q, got %q", "satellite-dish", agent.Icon)
+	}
+	if agent.SigningPublicKey == "" {
+		t.Fatal("expected stored SigningPublicKey to be set")
+	}
+	signingPubBytes, err := base64.StdEncoding.DecodeString(agent.SigningPublicKey)
+	if err != nil {
+		t.Fatalf("failed to decode stored SigningPublicKey: %v", err)
+	}
+	if !signingPriv.Public().(ed25519.PublicKey).Equal(ed25519.PublicKey(signingPubBytes)) {
+		t.Fatal("signing key encoded into the token does not match the stored SigningPublicKey")
 	}
 }
 
@@ -423,7 +440,11 @@ func TestRotateAgentTokenHandler_Success(t *testing.T) {
 		t.Fatal("expected authToken to be set")
 	}
 
-	claims, err := auth.ValidateAgentToken(body.AuthToken)
+	jwtToken, signingPriv, err := agenttoken.Decode(body.AuthToken)
+	if err != nil {
+		t.Fatalf("failed to decode compound auth token: %v", err)
+	}
+	claims, err := auth.ValidateAgentToken(jwtToken)
 	if err != nil {
 		t.Fatalf("failed to validate returned auth token: %v", err)
 	}
@@ -443,6 +464,16 @@ func TestRotateAgentTokenHandler_Success(t *testing.T) {
 	}
 	if updated.KeyId.String() != claims.KeyId {
 		t.Fatalf("expected stored KeyId %q to match token KeyId %q", updated.KeyId.String(), claims.KeyId)
+	}
+	if updated.SigningPublicKey == "" {
+		t.Fatal("expected stored SigningPublicKey to be set")
+	}
+	signingPubBytes, err := base64.StdEncoding.DecodeString(updated.SigningPublicKey)
+	if err != nil {
+		t.Fatalf("failed to decode stored SigningPublicKey: %v", err)
+	}
+	if !signingPriv.Public().(ed25519.PublicKey).Equal(ed25519.PublicKey(signingPubBytes)) {
+		t.Fatal("signing key encoded into the token does not match the stored SigningPublicKey")
 	}
 }
 

--- a/backend/internal/hub/websocket/handler.go
+++ b/backend/internal/hub/websocket/handler.go
@@ -2,6 +2,9 @@ package websocket
 
 import (
 	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -73,6 +76,13 @@ func WsHandler(h *Hub, log *zerolog.Logger) gin.HandlerFunc {
 			return
 		}
 
+		agentSigningPubKey, err := decodeAgentSigningPublicKey(agent.SigningPublicKey)
+		if err != nil {
+			log.Error().Err(err).Str("agent_id", claims.Subject).Msg("Invalid agent signing public key; re-issue the agent token")
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+
 		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 		if err != nil {
 			log.Error().Err(err).Msg("Upgrade error")
@@ -81,7 +91,7 @@ func WsHandler(h *Hub, log *zerolog.Logger) gin.HandlerFunc {
 
 		conn.SetReadLimit(20 << 20) // 20MB max message size to prevent DoS with large messages
 
-		session, err := performHandshake(conn, claims.Subject, log)
+		session, err := performHandshake(conn, claims.Subject, agentSigningPubKey, log)
 		if err != nil {
 			log.Error().Err(err).Str("agent_id", claims.Subject).Msg("Handshake failed")
 			err = conn.Close()
@@ -329,7 +339,18 @@ func failRunningDeploymentEventsForAgent(ctx context.Context, agentID string, lo
 	}
 }
 
-func performHandshake(conn WSConn, agentID string, log *zerolog.Logger) (*wscrypto.Session, error) {
+func decodeAgentSigningPublicKey(encoded string) (ed25519.PublicKey, error) {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode agent signing public key: %w", err)
+	}
+	if len(decoded) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("agent signing public key has invalid length %d, want %d", len(decoded), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(decoded), nil
+}
+
+func performHandshake(conn WSConn, agentID string, agentSigningPubKey ed25519.PublicKey, log *zerolog.Logger) (*wscrypto.Session, error) {
 	hubKeys, err := wscrypto.GenerateHubKeys()
 	if err != nil {
 		return nil, err
@@ -372,6 +393,11 @@ func performHandshake(conn WSConn, agentID string, log *zerolog.Logger) (*wscryp
 	resp, ok := clientMsg.Payload.(*messages.ClientMessage_KeyExchangeResponse)
 	if !ok {
 		return nil, fmt.Errorf("expected KeyExchangeResponse, got %T", clientMsg.Payload)
+	}
+
+	responsePayload := wscrypto.AgentResponseSignaturePayload(resp.KeyExchangeResponse.MlkemCiphertext, resp.KeyExchangeResponse.AgentX25519PublicKey, agentID)
+	if !ed25519.Verify(agentSigningPubKey, responsePayload, resp.KeyExchangeResponse.AgentSignature) {
+		return nil, errors.New("agent signature verification failed: agent identity not confirmed")
 	}
 
 	sessionKey, err := wscrypto.HubDeriveSessionKey(hubKeys, resp.KeyExchangeResponse.MlkemCiphertext, resp.KeyExchangeResponse.AgentX25519PublicKey, agentID)

--- a/backend/internal/hub/websocket/handler_test.go
+++ b/backend/internal/hub/websocket/handler_test.go
@@ -1,6 +1,8 @@
 package websocket
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"errors"
 	"log"
 	"net/http"
@@ -16,6 +18,7 @@ import (
 	"github.com/OrcaCD/orca-cd/internal/hub/db"
 	"github.com/OrcaCD/orca-cd/internal/hub/models"
 	messages "github.com/OrcaCD/orca-cd/internal/proto"
+	"github.com/OrcaCD/orca-cd/internal/shared/agenttoken"
 	"github.com/OrcaCD/orca-cd/internal/shared/wscrypto"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
@@ -90,7 +93,7 @@ func createTestAgent(t *testing.T, keyId string) *models.Agent {
 	return agent
 }
 
-func issueTokenAndPersistKeyID(t *testing.T, agent *models.Agent) string {
+func issueTokenAndPersistKeyID(t *testing.T, agent *models.Agent) (authToken string, signingPriv ed25519.PrivateKey) {
 	t.Helper()
 
 	token, err := auth.GenerateAgentToken(agent)
@@ -98,11 +101,19 @@ func issueTokenAndPersistKeyID(t *testing.T, agent *models.Agent) string {
 		t.Fatalf("failed to generate token: %v", err)
 	}
 
-	if _, err := gorm.G[models.Agent](db.DB).Where("id = ?", agent.Id).Update(t.Context(), "key_id", agent.KeyId); err != nil {
+	if _, err := gorm.G[models.Agent](db.DB).Where("id = ?", agent.Id).Updates(t.Context(), models.Agent{
+		KeyId:            agent.KeyId,
+		SigningPublicKey: agent.SigningPublicKey,
+	}); err != nil {
 		t.Fatalf("failed to persist rotated key id: %v", err)
 	}
 
-	return token
+	jwtToken, signingPriv, err := agenttoken.Decode(token)
+	if err != nil {
+		t.Fatalf("failed to decode compound token: %v", err)
+	}
+
+	return jwtToken, signingPriv
 }
 
 func newHandlerTestServer(t *testing.T, h *Hub) *httptest.Server {
@@ -170,7 +181,7 @@ func waitForUnregistered(t *testing.T, h *Hub, agentID string) {
 	t.Errorf("timed out waiting for agent %s registration to be released", agentID)
 }
 
-func doHandshake(t *testing.T, conn *websocket.Conn, agentID string) {
+func doHandshake(t *testing.T, conn *websocket.Conn, agentID string, signingPriv ed25519.PrivateKey) {
 	t.Helper()
 	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
 		t.Errorf("doHandshake: set deadline: %v", err)
@@ -181,10 +192,10 @@ func doHandshake(t *testing.T, conn *websocket.Conn, agentID string) {
 		t.Errorf("doHandshake: read: %v", err)
 		return
 	}
-	respondToHandshake(t, conn, data, agentID)
+	respondToHandshake(t, conn, data, agentID, signingPriv)
 }
 
-func respondToHandshake(t *testing.T, conn *websocket.Conn, data []byte, agentID string) {
+func respondToHandshake(t *testing.T, conn *websocket.Conn, data []byte, agentID string, signingPriv ed25519.PrivateKey) {
 	t.Helper()
 	serverMsg := &messages.ServerMessage{}
 	if err := proto.Unmarshal(data, serverMsg); err != nil {
@@ -205,11 +216,13 @@ func respondToHandshake(t *testing.T, conn *websocket.Conn, data []byte, agentID
 		t.Errorf("doHandshake: AgentHandshake: %v", err)
 		return
 	}
+	sig := signHandshakeResponse(t, signingPriv, mlkemCiphertext, agentX25519Pub, agentID)
 	resp := &messages.ClientMessage{
 		Payload: &messages.ClientMessage_KeyExchangeResponse{
 			KeyExchangeResponse: &messages.KeyExchangeResponse{
 				MlkemCiphertext:      mlkemCiphertext,
 				AgentX25519PublicKey: agentX25519Pub,
+				AgentSignature:       sig,
 			},
 		},
 	}
@@ -325,7 +338,7 @@ func TestWsHandler_RejectsReservedAgentBeforeUpgrade(t *testing.T) {
 	server := newHandlerTestServer(t, h)
 
 	agent := createTestAgent(t, "reserved-key-id")
-	token := issueTokenAndPersistKeyID(t, agent)
+	token, _ := issueTokenAndPersistKeyID(t, agent)
 	if _, err := h.Register(agent.Id, nil); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
@@ -350,7 +363,7 @@ func TestWsHandler_RejectsTokenRotatedDuringHandshake(t *testing.T) {
 	server := newHandlerTestServer(t, h)
 
 	agent := createTestAgent(t, "old-key-id")
-	token := issueTokenAndPersistKeyID(t, agent)
+	token, signingPriv := issueTokenAndPersistKeyID(t, agent)
 	conn, resp, err := dialWS(server, token)
 	if resp != nil {
 		defer resp.Body.Close() //nolint:errcheck
@@ -373,7 +386,7 @@ func TestWsHandler_RejectsTokenRotatedDuringHandshake(t *testing.T) {
 		t.Fatalf("rotate key during handshake: %v", err)
 	}
 
-	respondToHandshake(t, conn, initData, agent.Id)
+	respondToHandshake(t, conn, initData, agent.Id, signingPriv)
 	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
 		t.Fatalf("set close read deadline: %v", err)
 	}
@@ -390,7 +403,7 @@ func TestWsHandler_Success_ReceivesPing(t *testing.T) {
 	server := newHandlerTestServer(t, h)
 
 	agent := createTestAgent(t, "key-id-1")
-	token := issueTokenAndPersistKeyID(t, agent)
+	token, signingPriv := issueTokenAndPersistKeyID(t, agent)
 
 	conn, resp, err := dialWS(server, token)
 	if resp != nil {
@@ -399,7 +412,7 @@ func TestWsHandler_Success_ReceivesPing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected successful WS connection, got: %v", err)
 	}
-	doHandshake(t, conn, agent.Id)
+	doHandshake(t, conn, agent.Id, signingPriv)
 
 	// Wait for the server to register the client (with timeout).
 	msg := &messages.ServerMessage{
@@ -451,7 +464,7 @@ func TestWsHandler_HandlesPong(t *testing.T) {
 	server := newHandlerTestServer(t, h)
 
 	agent := createTestAgent(t, "key-id-2")
-	token := issueTokenAndPersistKeyID(t, agent)
+	token, signingPriv := issueTokenAndPersistKeyID(t, agent)
 
 	conn, resp, err := dialWS(server, token)
 	if resp != nil {
@@ -460,7 +473,7 @@ func TestWsHandler_HandlesPong(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected successful WS connection, got: %v", err)
 	}
-	doHandshake(t, conn, agent.Id)
+	doHandshake(t, conn, agent.Id, signingPriv)
 
 	// Wait for registration.
 	deadline := time.Now().Add(time.Second)
@@ -602,7 +615,7 @@ func TestWsHandler_AgentMarkedOfflineOnDisconnect(t *testing.T) {
 	server := newHandlerTestServer(t, h)
 
 	agent := createTestAgent(t, "key-id-3")
-	token := issueTokenAndPersistKeyID(t, agent)
+	token, signingPriv := issueTokenAndPersistKeyID(t, agent)
 
 	conn, resp, err := dialWS(server, token)
 	if resp != nil {
@@ -611,7 +624,7 @@ func TestWsHandler_AgentMarkedOfflineOnDisconnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected successful WS connection, got: %v", err)
 	}
-	doHandshake(t, conn, agent.Id)
+	doHandshake(t, conn, agent.Id, signingPriv)
 
 	// Wait for registration then close the connection.
 	deadline := time.Now().Add(time.Second)
@@ -649,7 +662,7 @@ func TestWsHandler_ServerDisconnectFinishesRegistration(t *testing.T) {
 	server := newHandlerTestServer(t, h)
 
 	agent := createTestAgent(t, "key-server-disconnect")
-	token := issueTokenAndPersistKeyID(t, agent)
+	token, signingPriv := issueTokenAndPersistKeyID(t, agent)
 	conn, resp, err := dialWS(server, token)
 	if resp != nil {
 		defer resp.Body.Close() //nolint:errcheck
@@ -658,7 +671,7 @@ func TestWsHandler_ServerDisconnectFinishesRegistration(t *testing.T) {
 		t.Fatalf("expected successful WS connection, got: %v", err)
 	}
 	defer conn.Close() //nolint:errcheck
-	doHandshake(t, conn, agent.Id)
+	doHandshake(t, conn, agent.Id, signingPriv)
 
 	var client *Client
 	deadline := time.Now().Add(time.Second)
@@ -730,7 +743,7 @@ func TestWsHandler_SendsAgentSettingsOnConnect(t *testing.T) {
 	server := newHandlerTestServer(t, h)
 
 	agent := createTestAgent(t, "key-sa-1")
-	token := issueTokenAndPersistKeyID(t, agent)
+	token, signingPriv := issueTokenAndPersistKeyID(t, agent)
 
 	conn, resp, err := dialWS(server, token)
 	if resp != nil {
@@ -739,7 +752,7 @@ func TestWsHandler_SendsAgentSettingsOnConnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected successful WS connection, got: %v", err)
 	}
-	doHandshake(t, conn, agent.Id)
+	doHandshake(t, conn, agent.Id, signingPriv)
 
 	// The WsHandler sends an encrypted AgentSettings message immediately after
 	// registration. Read and discard it to verify the code path was reached.
@@ -760,12 +773,22 @@ func TestWsHandler_SendsAgentSettingsOnConnect(t *testing.T) {
 	waitForOffline(t, agent.Id)
 }
 
+// signHandshakeResponse signs an agent's KeyExchangeResponse payload for testing.
+func signHandshakeResponse(t *testing.T, priv ed25519.PrivateKey, mlkemCiphertext, agentX25519PubKey []byte, agentID string) []byte {
+	t.Helper()
+	return ed25519.Sign(priv, wscrypto.AgentResponseSignaturePayload(mlkemCiphertext, agentX25519PubKey, agentID))
+}
+
 func TestPerformHandshake_WriteDeadlineError(t *testing.T) {
 	setupHandlerTestEnv(t)
 	log := testLogger()
 	conn := &MockConn{writeDeadErr: errors.New("failed to set write deadline")}
+	agentSigningPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
 
-	session, err := performHandshake(conn, "test-agent-id", &log)
+	session, err := performHandshake(conn, "test-agent-id", agentSigningPub, &log)
 	if err == nil {
 		t.Error("expected error from SetWriteDeadline, got nil")
 	}
@@ -781,8 +804,12 @@ func TestPerformHandshake_WriteMessageError(t *testing.T) {
 	setupHandlerTestEnv(t)
 	log := testLogger()
 	conn := &MockConn{writeErr: errors.New("failed to write message")}
+	agentSigningPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
 
-	session, err := performHandshake(conn, "test-agent-id", &log)
+	session, err := performHandshake(conn, "test-agent-id", agentSigningPub, &log)
 	if err == nil {
 		t.Error("expected error from WriteMessage, got nil")
 	}
@@ -798,8 +825,12 @@ func TestPerformHandshake_ReadDeadlineError(t *testing.T) {
 	setupHandlerTestEnv(t)
 	log := testLogger()
 	conn := &MockConn{readDeadErr: errors.New("failed to set read deadline")}
+	agentSigningPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
 
-	session, err := performHandshake(conn, "test-agent-id", &log)
+	session, err := performHandshake(conn, "test-agent-id", agentSigningPub, &log)
 	if err == nil {
 		t.Error("expected error from SetReadDeadline, got nil")
 	}
@@ -814,8 +845,12 @@ func TestPerformHandshake_ReadDeadlineError(t *testing.T) {
 func TestPerformHandshake_ReadMessageError(t *testing.T) {
 	log := testLogger()
 	conn := &MockConn{readErr: errors.New("connection closed")}
+	agentSigningPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
 
-	session, err := performHandshake(conn, "test-agent-id", &log)
+	session, err := performHandshake(conn, "test-agent-id", agentSigningPub, &log)
 	if err == nil {
 		t.Error("expected error from ReadMessage, got nil")
 	}
@@ -831,8 +866,12 @@ func TestPerformHandshake_UnmarshalError(t *testing.T) {
 	conn := &MockConn{
 		messages: [][]byte{{0xFF, 0xFF, 0xFF, 0xFF}},
 	}
+	agentSigningPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
 
-	session, err := performHandshake(conn, "test-agent-id", &log)
+	session, err := performHandshake(conn, "test-agent-id", agentSigningPub, &log)
 	if err == nil {
 		t.Error("expected error from proto.Unmarshal, got nil")
 	}
@@ -859,8 +898,12 @@ func TestPerformHandshake_InvalidResponseType(t *testing.T) {
 	conn := &MockConn{
 		messages: [][]byte{data},
 	}
+	agentSigningPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
 
-	session, err := performHandshake(conn, "test-agent-id", &log)
+	session, err := performHandshake(conn, "test-agent-id", agentSigningPub, &log)
 	if err == nil {
 		t.Error("expected error for invalid response type, got nil")
 	}
@@ -876,13 +919,24 @@ func TestPerformHandshake_DerivationError(t *testing.T) {
 	setupHandlerTestEnv(t)
 	log := testLogger()
 
+	agentSigningPub, agentSigningPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
 	// Create valid handshake init, but respond with invalid derivation data
-	// Send KeyExchangeResponse with invalid ciphertext (too short, will fail MLKEM decapsulation)
+	// Send KeyExchangeResponse with invalid ciphertext (too short, will fail MLKEM decapsulation),
+	// but a correctly computed signature over it so the derivation error (not a
+	// signature error) is what's actually exercised.
+	invalidCiphertext := []byte{0x00}
+	agentX25519Pub := make([]byte, 32)
+	sig := signHandshakeResponse(t, agentSigningPriv, invalidCiphertext, agentX25519Pub, "test-agent-id")
 	resp := &messages.ClientMessage{
 		Payload: &messages.ClientMessage_KeyExchangeResponse{
 			KeyExchangeResponse: &messages.KeyExchangeResponse{
-				MlkemCiphertext:      []byte{0x00}, // invalid MLKEM ciphertext
-				AgentX25519PublicKey: make([]byte, 32),
+				MlkemCiphertext:      invalidCiphertext,
+				AgentX25519PublicKey: agentX25519Pub,
+				AgentSignature:       sig,
 			},
 		},
 	}
@@ -895,7 +949,7 @@ func TestPerformHandshake_DerivationError(t *testing.T) {
 		messages: [][]byte{respData},
 	}
 
-	session, err := performHandshake(conn, "test-agent-id", &log)
+	session, err := performHandshake(conn, "test-agent-id", agentSigningPub, &log)
 	if err == nil {
 		t.Error("expected error from key derivation, got nil")
 	}
@@ -914,6 +968,11 @@ func TestPerformHandshake_Success(t *testing.T) {
 		t.Fatalf("failed to generate hub keys: %v", err)
 	}
 
+	agentSigningPub, agentSigningPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
 	// Client performs handshake
 	mlkemCiphertext, agentX25519Pub, _, err := wscrypto.AgentHandshake(
 		hubKeys.MLKEMEncapKey,
@@ -923,8 +982,122 @@ func TestPerformHandshake_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AgentHandshake failed: %v", err)
 	}
+	sig := signHandshakeResponse(t, agentSigningPriv, mlkemCiphertext, agentX25519Pub, agentID)
 
 	// Server reads this response
+	resp := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_KeyExchangeResponse{
+			KeyExchangeResponse: &messages.KeyExchangeResponse{
+				MlkemCiphertext:      mlkemCiphertext,
+				AgentX25519PublicKey: agentX25519Pub,
+				AgentSignature:       sig,
+			},
+		},
+	}
+	respData, err := proto.Marshal(resp)
+	if err != nil {
+		t.Fatalf("failed to marshal response: %v", err)
+	}
+
+	conn := &MockConn{
+		messages: [][]byte{respData},
+	}
+
+	session, err := performHandshake(conn, agentID, agentSigningPub, &log)
+	if err != nil {
+		t.Fatalf("performHandshake failed: %v", err)
+	}
+	if session == nil {
+		t.Fatal("expected non-nil session")
+	}
+}
+
+func TestPerformHandshake_InvalidAgentSignature(t *testing.T) {
+	setupHandlerTestEnv(t)
+	log := testLogger()
+
+	agentID := "test-agent-id"
+	hubKeys, err := wscrypto.GenerateHubKeys()
+	if err != nil {
+		t.Fatalf("failed to generate hub keys: %v", err)
+	}
+
+	agentSigningPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	// A different keypair signs the response — verification against
+	// agentSigningPub must fail.
+	_, wrongSigningPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	mlkemCiphertext, agentX25519Pub, _, err := wscrypto.AgentHandshake(
+		hubKeys.MLKEMEncapKey,
+		hubKeys.X25519PublicKey,
+		agentID,
+	)
+	if err != nil {
+		t.Fatalf("AgentHandshake failed: %v", err)
+	}
+	sig := signHandshakeResponse(t, wrongSigningPriv, mlkemCiphertext, agentX25519Pub, agentID)
+
+	resp := &messages.ClientMessage{
+		Payload: &messages.ClientMessage_KeyExchangeResponse{
+			KeyExchangeResponse: &messages.KeyExchangeResponse{
+				MlkemCiphertext:      mlkemCiphertext,
+				AgentX25519PublicKey: agentX25519Pub,
+				AgentSignature:       sig,
+			},
+		},
+	}
+	respData, err := proto.Marshal(resp)
+	if err != nil {
+		t.Fatalf("failed to marshal response: %v", err)
+	}
+
+	conn := &MockConn{
+		messages: [][]byte{respData},
+	}
+
+	session, err := performHandshake(conn, agentID, agentSigningPub, &log)
+	if err == nil {
+		t.Fatal("expected error for invalid agent signature")
+	}
+	if session != nil {
+		t.Error("expected nil session on error")
+	}
+	if !strings.Contains(err.Error(), "agent signature") {
+		t.Errorf("expected error mentioning agent signature, got: %v", err)
+	}
+}
+
+func TestPerformHandshake_MissingAgentSignature(t *testing.T) {
+	setupHandlerTestEnv(t)
+	log := testLogger()
+
+	agentID := "test-agent-id"
+	hubKeys, err := wscrypto.GenerateHubKeys()
+	if err != nil {
+		t.Fatalf("failed to generate hub keys: %v", err)
+	}
+
+	agentSigningPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	mlkemCiphertext, agentX25519Pub, _, err := wscrypto.AgentHandshake(
+		hubKeys.MLKEMEncapKey,
+		hubKeys.X25519PublicKey,
+		agentID,
+	)
+	if err != nil {
+		t.Fatalf("AgentHandshake failed: %v", err)
+	}
+
+	// No AgentSignature set at all.
 	resp := &messages.ClientMessage{
 		Payload: &messages.ClientMessage_KeyExchangeResponse{
 			KeyExchangeResponse: &messages.KeyExchangeResponse{
@@ -942,11 +1115,11 @@ func TestPerformHandshake_Success(t *testing.T) {
 		messages: [][]byte{respData},
 	}
 
-	session, err := performHandshake(conn, agentID, &log)
-	if err != nil {
-		t.Fatalf("performHandshake failed: %v", err)
+	session, err := performHandshake(conn, agentID, agentSigningPub, &log)
+	if err == nil {
+		t.Fatal("expected error for missing agent signature")
 	}
-	if session == nil {
-		t.Fatal("expected non-nil session")
+	if session != nil {
+		t.Error("expected nil session on error")
 	}
 }

--- a/backend/internal/proto/messages.pb.go
+++ b/backend/internal/proto/messages.pb.go
@@ -546,6 +546,7 @@ type KeyExchangeResponse struct {
 	state                protoimpl.MessageState `protogen:"open.v1"`
 	MlkemCiphertext      []byte                 `protobuf:"bytes,1,opt,name=mlkem_ciphertext,json=mlkemCiphertext,proto3" json:"mlkem_ciphertext,omitempty"`
 	AgentX25519PublicKey []byte                 `protobuf:"bytes,2,opt,name=agent_x25519_public_key,json=agentX25519PublicKey,proto3" json:"agent_x25519_public_key,omitempty"`
+	AgentSignature       []byte                 `protobuf:"bytes,3,opt,name=agent_signature,json=agentSignature,proto3" json:"agent_signature,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -590,6 +591,13 @@ func (x *KeyExchangeResponse) GetMlkemCiphertext() []byte {
 func (x *KeyExchangeResponse) GetAgentX25519PublicKey() []byte {
 	if x != nil {
 		return x.AgentX25519PublicKey
+	}
+	return nil
+}
+
+func (x *KeyExchangeResponse) GetAgentSignature() []byte {
+	if x != nil {
+		return x.AgentSignature
 	}
 	return nil
 }
@@ -1294,10 +1302,11 @@ const file_messages_proto_rawDesc = "" +
 	"\x0fKeyExchangeInit\x126\n" +
 	"\x17mlkem_encapsulation_key\x18\x01 \x01(\fR\x15mlkemEncapsulationKey\x12*\n" +
 	"\x11x25519_public_key\x18\x02 \x01(\fR\x0fx25519PublicKey\x12#\n" +
-	"\rhub_signature\x18\x03 \x01(\fR\fhubSignature\"w\n" +
+	"\rhub_signature\x18\x03 \x01(\fR\fhubSignature\"\xa0\x01\n" +
 	"\x13KeyExchangeResponse\x12)\n" +
 	"\x10mlkem_ciphertext\x18\x01 \x01(\fR\x0fmlkemCiphertext\x125\n" +
-	"\x17agent_x25519_public_key\x18\x02 \x01(\fR\x14agentX25519PublicKey\"H\n" +
+	"\x17agent_x25519_public_key\x18\x02 \x01(\fR\x14agentX25519PublicKey\x12'\n" +
+	"\x0fagent_signature\x18\x03 \x01(\fR\x0eagentSignature\"H\n" +
 	"\x10EncryptedPayload\x12\x14\n" +
 	"\x05nonce\x18\x01 \x01(\fR\x05nonce\x12\x1e\n" +
 	"\n" +

--- a/backend/internal/proto/messages.proto
+++ b/backend/internal/proto/messages.proto
@@ -45,6 +45,7 @@ message KeyExchangeInit {
 message KeyExchangeResponse {
   bytes mlkem_ciphertext = 1;
   bytes agent_x25519_public_key = 2;
+  bytes agent_signature = 3;
 }
 
 message EncryptedPayload {

--- a/backend/internal/shared/agenttoken/agenttoken.go
+++ b/backend/internal/shared/agenttoken/agenttoken.go
@@ -1,0 +1,38 @@
+// Package agenttoken encodes/decodes the compound token an admin copies from the
+// hub UI into an agent's AUTH_TOKEN: a signed JWT (used for HTTP/WS bearer auth)
+// with the agent's Ed25519 handshake-signing seed appended. The signing key never
+// travels over the wire again after this and the agent uses it locally to sign its
+// KeyExchangeResponse during the WS handshake.
+package agenttoken
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func Encode(jwt string, signingSeed []byte) (string, error) {
+	if len(signingSeed) != ed25519.SeedSize {
+		return "", fmt.Errorf("agenttoken.Encode: signing seed must be %d bytes, got %d", ed25519.SeedSize, len(signingSeed))
+	}
+	return jwt + "." + base64.RawURLEncoding.EncodeToString(signingSeed), nil
+}
+
+func Decode(token string) (jwt string, signingKey ed25519.PrivateKey, err error) {
+	parts := strings.SplitN(token, ".", 4)
+	if len(parts) != 4 {
+		return "", nil, errors.New("token is missing signing-key segment; re-issue the agent token from the hub")
+	}
+
+	seed, err := base64.RawURLEncoding.DecodeString(parts[3])
+	if err != nil {
+		return "", nil, fmt.Errorf("agenttoken.Decode: invalid signing-key segment: %w", err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		return "", nil, fmt.Errorf("agenttoken.Decode: signing-key segment must be %d bytes, got %d", ed25519.SeedSize, len(seed))
+	}
+
+	return strings.Join(parts[:3], "."), ed25519.NewKeyFromSeed(seed), nil
+}

--- a/backend/internal/shared/agenttoken/agenttoken_test.go
+++ b/backend/internal/shared/agenttoken/agenttoken_test.go
@@ -1,0 +1,60 @@
+package agenttoken
+
+import (
+	"crypto/ed25519"
+	"testing"
+)
+
+func TestEncodeDecode_RoundTrip(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	const jwt = "header.payload.signature"
+
+	token, err := Encode(jwt, priv.Seed())
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	gotJWT, gotKey, err := Decode(token)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if gotJWT != jwt {
+		t.Errorf("gotJWT = %q, want %q", gotJWT, jwt)
+	}
+	if !gotKey.Public().(ed25519.PublicKey).Equal(pub) {
+		t.Error("decoded signing key does not match original public key")
+	}
+}
+
+func TestEncode_InvalidSeedLength(t *testing.T) {
+	_, err := Encode("header.payload.signature", make([]byte, 10))
+	if err == nil {
+		t.Fatal("expected error for invalid seed length")
+	}
+}
+
+func TestDecode_MissingSegment(t *testing.T) {
+	_, _, err := Decode("header.payload.signature")
+	if err == nil {
+		t.Fatal("expected error for token missing signing-key segment")
+	}
+}
+
+func TestDecode_InvalidBase64Segment(t *testing.T) {
+	_, _, err := Decode("header.payload.signature.not-valid-base64!!!")
+	if err == nil {
+		t.Fatal("expected error for invalid base64 signing-key segment")
+	}
+}
+
+func TestDecode_WrongSeedLength(t *testing.T) {
+	// valid base64url but wrong decoded length
+	_, _, err := Decode("header.payload.signature.YWJj")
+	if err == nil {
+		t.Fatal("expected error for wrong seed length")
+	}
+}

--- a/backend/internal/shared/wscrypto/handshake.go
+++ b/backend/internal/shared/wscrypto/handshake.go
@@ -109,3 +109,14 @@ func HandshakeSignaturePayload(mlkemEncapKey, x25519PublicKey []byte, agentID st
 	payload = append(payload, agentID...)
 	return payload
 }
+
+// AgentResponseSignaturePayload is the mirror of HandshakeSignaturePayload for the
+// agent->hub direction: the agent signs this with its per-agent Ed25519 key so the
+// hub can confirm the KeyExchangeResponse actually came from the enrolled agent.
+func AgentResponseSignaturePayload(mlkemCiphertext, agentX25519PubKey []byte, agentID string) []byte {
+	payload := make([]byte, 0, len(mlkemCiphertext)+len(agentX25519PubKey)+len(agentID))
+	payload = append(payload, mlkemCiphertext...)
+	payload = append(payload, agentX25519PubKey...)
+	payload = append(payload, agentID...)
+	return payload
+}

--- a/backend/internal/shared/wscrypto/handshake_test.go
+++ b/backend/internal/shared/wscrypto/handshake_test.go
@@ -6,6 +6,34 @@ import (
 	"testing"
 )
 
+func TestAgentResponseSignaturePayload_Deterministic(t *testing.T) {
+	ciphertext := []byte("mlkem-ciphertext")
+	x25519Pub := []byte("x25519-pub")
+	agentID := "agent-1"
+
+	a := AgentResponseSignaturePayload(ciphertext, x25519Pub, agentID)
+	b := AgentResponseSignaturePayload(ciphertext, x25519Pub, agentID)
+	if !bytes.Equal(a, b) {
+		t.Error("expected identical inputs to produce identical payloads")
+	}
+}
+
+func TestAgentResponseSignaturePayload_DiffersOnInputChange(t *testing.T) {
+	base := AgentResponseSignaturePayload([]byte("ciphertext"), []byte("x25519-pub"), "agent-1")
+
+	cases := map[string][]byte{
+		"different ciphertext": AgentResponseSignaturePayload([]byte("other-ciphertext"), []byte("x25519-pub"), "agent-1"),
+		"different x25519 pub": AgentResponseSignaturePayload([]byte("ciphertext"), []byte("other-pub"), "agent-1"),
+		"different agentID":    AgentResponseSignaturePayload([]byte("ciphertext"), []byte("x25519-pub"), "agent-2"),
+	}
+
+	for name, payload := range cases {
+		if bytes.Equal(base, payload) {
+			t.Errorf("%s: expected payload to differ from base", name)
+		}
+	}
+}
+
 func TestFullHandshake(t *testing.T) {
 	hubKeys, err := GenerateHubKeys()
 	if err != nil {


### PR DESCRIPTION
## **Type of change**

- [ ] 🐛 Bug fix
- [x] 🚀 New feature (Breaking)
- [ ] ❓ Other (please specify)

## **Description**

Enhance handshake security by signing the agent response with a long term pre-shared key. This prevents a man in the middle reading the auth token header to spoof the connection. Before it was already not possible to spoof the hub, but a agent could be spoofed if a malicious actor could get in the middle of the websocket connection during a handshake. 

## **Additional context**

This requires all Agent tokens to be re-issued!!!
